### PR TITLE
Emulate L1 Hypervisor CSR and Setting Shadow Page Table

### DIFF
--- a/arch/src/riscv/cpu.rs
+++ b/arch/src/riscv/cpu.rs
@@ -75,8 +75,7 @@ pub mod csr_address {
     pub const CSR_HGATP_ADDRESS: usize = 0x680;
 
     pub fn is_hypervisor_csr(csr_number: usize) -> bool {
-        csr_number & 0x600 == 0x600 ||
-        csr_number == CSR_HGEIP_ADDRESS
+        csr_number & 0x600 == 0x600 || csr_number == CSR_HGEIP_ADDRESS
     }
 }
 

--- a/arch/src/riscv/cpu.rs
+++ b/arch/src/riscv/cpu.rs
@@ -83,7 +83,7 @@ pub mod csr_address {
     pub const CSR_HGATP_ADDRESS: usize = 0x680;
 
     pub fn is_hypervisor_csr(csr_number: usize) -> bool {
-        csr_number & 0x600 == 0x600 || csr_number == CSR_HGEIP_ADDRESS
+        (csr_number & 0xF00) == 0x600 || csr_number == CSR_HGEIP_ADDRESS
     }
 }
 

--- a/arch/src/riscv/cpu.rs
+++ b/arch/src/riscv/cpu.rs
@@ -8,6 +8,10 @@ pub const MIE_MEIE_OFFSET: usize = 11;
 
 pub const MSTATUS_SIE: usize = 1 << 1;
 pub const MSTATUS_MIE: usize = 1 << 3;
+pub const MSTATUS_MPP_0: usize = 1 << 11;
+pub const MSTATUS_MPP_1: usize = 1 << 12;
+pub const MSTATUS_MPRV: usize = 1 << 17;
+pub const MSTATUS_MPV: usize = 1 << 39;
 
 pub const MIE_MEIE: usize = 1 << 11; // 外部割込み許可
 pub const MIE_VSEIE: usize = 1 << 10;

--- a/arch/src/riscv/cpu.rs
+++ b/arch/src/riscv/cpu.rs
@@ -11,9 +11,15 @@ pub const MSTATUS_MIE: usize = 1 << 3;
 pub const MSTATUS_MPP_0: usize = 1 << 11;
 pub const MSTATUS_MPP_1: usize = 1 << 12;
 pub const MSTATUS_MPRV: usize = 1 << 17;
+pub const MSTATUS_TSR: usize = 1 << 22;
 pub const MSTATUS_MPV: usize = 1 << 39;
 
+pub const SSTATUS_SPP: usize = 1 << 8;
+
+pub const HSTATUS_VSBE: usize = 1 << 5;
+pub const HSTATUS_SPV: usize = 1 << 7;
 pub const HSTATUS_SPVP: usize = 1 << 8;
+pub const HSTATUS_VSTR: usize = 1 << 22;
 
 pub const MIE_MEIE: usize = 1 << 11; // 外部割込み許可
 pub const MIE_VSEIE: usize = 1 << 10;
@@ -43,16 +49,12 @@ pub const SATP_PPN_MASK: usize = (1 << 44) - 1;
 pub const SATP_MODE_MASK: usize = ((1 << 4) - 1) << 60;
 pub const SATP_ASID_MASK: usize = ((1 << 14) - 1) << 44;
 
-pub const MSTATUS_TVM_OFFSET: usize = 20;
-
 pub const PMP_1_CFG_OFFSET: usize = 8;
 pub const PMP_A_FIELD_OFFSET: usize = 3;
 
 pub const PMP_A_FIELD_TOR: usize = 1;
 pub const PMP_A_FIELD_NA4: usize = 2;
 pub const PMP_A_FIELD_NAPOT: usize = 3;
-
-pub const HSTATUS_VSBE_OFFSET: usize = 5;
 
 pub const ENVCFG_ADUE_OFFSET: usize = 61;
 

--- a/arch/src/riscv/cpu.rs
+++ b/arch/src/riscv/cpu.rs
@@ -51,9 +51,29 @@ pub const HSTATUS_VSBE_OFFSET: usize = 5;
 pub const ENVCFG_ADUE_OFFSET: usize = 61;
 
 // CSRs address
-pub const CSR_MHARTID_ADDRESS: usize = 0xf14;
-pub const CSR_MIE_ADDRESS: usize = 0x304;
-pub const CSR_TIME_ADDRESS: usize = 0xc01;
+pub mod csr_address {
+    // Machine
+    pub const CSR_MHARTID_ADDRESS: usize = 0xf14;
+    pub const CSR_MIE_ADDRESS: usize = 0x304;
+    pub const CSR_TIME_ADDRESS: usize = 0xc01;
+    // Hypervisor Trap Setup
+    pub const CSR_HSTATUS_ADDRESS: usize = 0x600;
+    pub const CSR_HEDELEG_ADDRESS: usize = 0x602;
+    pub const CSR_HIDELEG_ADDRESS: usize = 0x603;
+    pub const CSR_HIE_ADDRESS: usize = 0x604;
+    pub const CSR_HCOUNTEREN_ADDRESS: usize = 0x606;
+    pub const CSR_HGEIE_ADDRESS: usize = 0x607;
+    // Hypervisor Trap Handling
+    pub const CSR_HTVAL_ADDRESS: usize = 0x643;
+    pub const CSR_HIP_ADDRESS: usize = 0x644;
+    pub const CSR_HVIP_ADDRESS: usize = 0x645;
+    pub const CSR_HTINST_ADDRESS: usize = 0x64a;
+    pub const CSR_HGEIP_ADDRESS: usize = 0xe12;
+    // Hypervisor Configuration
+    pub const CSR_HENVCFG_ADDRESS: usize = 0x60a;
+    // Hypervisor Protection and Translation
+    pub const CSR_HGATP_ADDRESS: usize = 0x680;
+}
 
 // Registers
 pub const REGISTER_ZERO: usize = 0;

--- a/arch/src/riscv/cpu.rs
+++ b/arch/src/riscv/cpu.rs
@@ -13,6 +13,8 @@ pub const MSTATUS_MPP_1: usize = 1 << 12;
 pub const MSTATUS_MPRV: usize = 1 << 17;
 pub const MSTATUS_MPV: usize = 1 << 39;
 
+pub const HSTATUS_SPVP: usize = 1 << 8;
+
 pub const MIE_MEIE: usize = 1 << 11; // 外部割込み許可
 pub const MIE_VSEIE: usize = 1 << 10;
 pub const MIE_MTIE: usize = 1 << 7; // タイマ割込み許可

--- a/arch/src/riscv/cpu.rs
+++ b/arch/src/riscv/cpu.rs
@@ -73,6 +73,11 @@ pub mod csr_address {
     pub const CSR_HENVCFG_ADDRESS: usize = 0x60a;
     // Hypervisor Protection and Translation
     pub const CSR_HGATP_ADDRESS: usize = 0x680;
+
+    pub fn is_hypervisor_csr(csr_number: usize) -> bool {
+        csr_number & 0x600 == 0x600 ||
+        csr_number == CSR_HGEIP_ADDRESS
+    }
 }
 
 // Registers

--- a/arch/src/riscv/instruction.rs
+++ b/arch/src/riscv/instruction.rs
@@ -55,7 +55,7 @@ impl Instruction {
     pub fn get_rs2(&self) -> usize {
         ((self.0 & Self::RS2_MASK) >> Self::RS2_OFFSET) as usize
     }
-    
+
     pub fn get_funct7(&self) -> usize {
         ((self.0 & Self::FUNCT7_MASK) >> Self::FUNCT7_OFFSET) as usize
     }
@@ -81,7 +81,9 @@ impl Instruction {
     }
 
     pub fn is_sret(&self) -> bool {
-        self.get_opcode() == Self::OPCODE_SYSTEM && self.get_rs2() == Self::RS2_TRAP_RETURN && self.get_funct7() == Self::FUNCT7_SRET
+        self.get_opcode() == Self::OPCODE_SYSTEM
+            && self.get_rs2() == Self::RS2_TRAP_RETURN
+            && self.get_funct7() == Self::FUNCT7_SRET
     }
 
     pub fn is_compression_instruction(&mut self) -> bool {

--- a/arch/src/riscv/instruction.rs
+++ b/arch/src/riscv/instruction.rs
@@ -31,7 +31,7 @@ impl Instruction {
         ((self.0 & Self::OPCODE_MASK) >> Self::OPCODE_OFFSET) as usize
     }
 
-    pub fn get_rd(&mut self) -> usize {
+    pub fn get_rd(&self) -> usize {
         ((self.0 & Self::RD_MASK) >> Self::RD_OFFSET) as usize
     }
 

--- a/arch/src/riscv/instruction.rs
+++ b/arch/src/riscv/instruction.rs
@@ -126,7 +126,7 @@ pub fn read_vm_memory(is_vu: bool, address: usize, width: usize) -> u64 {
             );
             output as u64
         },
-        _ => 0,
+        _ => panic!("Unsupported memory access width: {}", width),
     }
 }
 
@@ -149,6 +149,6 @@ pub fn write_vm_memory(is_vu: bool, address: usize, value: u64, width: usize) {
                 in(reg) address
             );
         },
-        _ => {}
+        _ => panic!("Unsupported memory access width: {}", width),
     }
 }

--- a/arch/src/riscv/instruction.rs
+++ b/arch/src/riscv/instruction.rs
@@ -1,5 +1,8 @@
 #![allow(dead_code)]
 
+use crate::riscv::cpu::{HSTATUS_SPVP, get_hstatus, set_hstatus};
+use core::arch::asm;
+
 pub struct Instruction(u32);
 
 impl Instruction {
@@ -70,5 +73,66 @@ impl Instruction {
     pub fn is_compression_instruction(&mut self) -> bool {
         let compression = self.get_compression();
         compression == Self::COMPRESSED_INSTRUCTION
+    }
+}
+
+// Hypervisor Instruction
+fn hstatus_effective_privileged(is_vu: bool) {
+    let mut hstatus = get_hstatus();
+    if is_vu {
+        hstatus &= !HSTATUS_SPVP as u64;
+    } else {
+        hstatus |= HSTATUS_SPVP as u64;
+    }
+    set_hstatus(hstatus);
+}
+
+pub fn read_vm_memory(is_vu: bool, address: usize, width: usize) -> u64 {
+    hstatus_effective_privileged(is_vu);
+    match width {
+        64 => unsafe {
+            let output: u64;
+            asm!("
+                .option arch, +h
+                hlv.d {0}, 0({1})",
+                out(reg) output,
+                in(reg) address
+            );
+            output
+        },
+        32 => unsafe {
+            let output: u32;
+            asm!("
+                .option arch, +h
+                hlv.w {0}, 0({1})",
+                out(reg) output,
+                in(reg) address
+            );
+            output as u64
+        },
+        _ => 0,
+    }
+}
+
+pub fn write_vm_memory(is_vu: bool, address: usize, value: u64, width: usize) {
+    hstatus_effective_privileged(is_vu);
+    match width {
+        64 => unsafe {
+            asm!("
+                .option arch, +h
+                hsv.d {0}, 0({1})",
+                in(reg) value,
+                in(reg) address
+            );
+        },
+        32 => unsafe {
+            asm!("
+                .option arch, +h
+                hsv.w {0}, 0({1})",
+                in(reg) value as u32,
+                in(reg) address
+            );
+        },
+        _ => {}
     }
 }

--- a/arch/src/riscv/instruction.rs
+++ b/arch/src/riscv/instruction.rs
@@ -16,6 +16,8 @@ impl Instruction {
     const RS1_MASK: u32 = ((1 << 5) - 1) << Self::RS1_OFFSET;
     const RS2_OFFSET: u32 = 20;
     const RS2_MASK: u32 = ((1 << 5) - 1) << Self::RS2_OFFSET;
+    const FUNCT7_OFFSET: u32 = 25;
+    const FUNCT7_MASK: u32 = ((1 << 7) - 1) << Self::FUNCT7_OFFSET;
     const FUNCT12_OFFSET: u32 = 20;
     const FUNCT12_MASK: u32 = ((1 << 12) - 1) << Self::FUNCT12_OFFSET;
     const COMPRESSION_OFFSET: u32 = 0;
@@ -24,6 +26,10 @@ impl Instruction {
     const OPCODE_SYSTEM: usize = 0b1110011;
     const FUNCT3_CSRRS: usize = 0b010;
     const FUNCT3_CSRRW: usize = 0b001;
+    const FUNCT7_SRET: usize = 0b0001000;
+    const FUNCT7_MRET: usize = 0b0011000;
+    const FUNCT7_MNRET: usize = 0b0111000;
+    const RS2_TRAP_RETURN: usize = 0b00010;
     const COMPRESSED_INSTRUCTION: usize = 0b01;
 
     pub const fn new(instruction: u32) -> Self {
@@ -42,12 +48,16 @@ impl Instruction {
         ((self.0 & Self::FUNCT3_MASK) >> Self::FUNCT3_OFFSET) as usize
     }
 
-    pub fn get_rs1(&mut self) -> usize {
+    pub fn get_rs1(&self) -> usize {
         ((self.0 & Self::RS1_MASK) >> Self::RS1_OFFSET) as usize
     }
 
-    pub fn get_rs2(&mut self) -> usize {
+    pub fn get_rs2(&self) -> usize {
         ((self.0 & Self::RS2_MASK) >> Self::RS2_OFFSET) as usize
+    }
+    
+    pub fn get_funct7(&self) -> usize {
+        ((self.0 & Self::FUNCT7_MASK) >> Self::FUNCT7_OFFSET) as usize
     }
 
     pub fn get_funct12(&self) -> usize {
@@ -66,8 +76,12 @@ impl Instruction {
         self.get_opcode() == Self::OPCODE_SYSTEM && self.get_funct3() == Self::FUNCT3_CSRRW
     }
 
-    pub fn is_csrrs_instruction(&mut self) -> bool {
+    pub fn is_csrrs_instruction(&self) -> bool {
         self.get_opcode() == Self::OPCODE_SYSTEM && self.get_funct3() == Self::FUNCT3_CSRRS
+    }
+
+    pub fn is_sret(&self) -> bool {
+        self.get_opcode() == Self::OPCODE_SYSTEM && self.get_rs2() == Self::RS2_TRAP_RETURN && self.get_funct7() == Self::FUNCT7_SRET
     }
 
     pub fn is_compression_instruction(&mut self) -> bool {

--- a/arch/src/riscv/instruction.rs
+++ b/arch/src/riscv/instruction.rs
@@ -18,7 +18,7 @@ impl Instruction {
     const COMPRESSION_OFFSET: u32 = 0;
     const COMPRESSION_MASK: u32 = ((1 << 2) - 1) << Self::COMPRESSION_OFFSET;
 
-    const OPCODE_CSR: usize = 0b1110011;
+    const OPCODE_SYSTEM: usize = 0b1110011;
     const FUNCT3_CSRRS: usize = 0b010;
     const FUNCT3_CSRRW: usize = 0b001;
     const COMPRESSED_INSTRUCTION: usize = 0b01;
@@ -27,7 +27,7 @@ impl Instruction {
         Self(instruction)
     }
 
-    pub fn get_opcode(&mut self) -> usize {
+    pub fn get_opcode(&self) -> usize {
         ((self.0 & Self::OPCODE_MASK) >> Self::OPCODE_OFFSET) as usize
     }
 
@@ -35,7 +35,7 @@ impl Instruction {
         ((self.0 & Self::RD_MASK) >> Self::RD_OFFSET) as usize
     }
 
-    pub fn get_funct3(&mut self) -> usize {
+    pub fn get_funct3(&self) -> usize {
         ((self.0 & Self::FUNCT3_MASK) >> Self::FUNCT3_OFFSET) as usize
     }
 
@@ -47,7 +47,7 @@ impl Instruction {
         ((self.0 & Self::RS2_MASK) >> Self::RS2_OFFSET) as usize
     }
 
-    pub fn get_funct12(&mut self) -> usize {
+    pub fn get_funct12(&self) -> usize {
         ((self.0 & Self::FUNCT12_MASK) >> Self::FUNCT12_OFFSET) as usize
     }
 
@@ -59,8 +59,12 @@ impl Instruction {
         self.0 != 0
     }
 
+    pub fn is_csrrw_instruction(&self) -> bool {
+        self.get_opcode() == Self::OPCODE_SYSTEM && self.get_funct3() == Self::FUNCT3_CSRRW
+    }
+
     pub fn is_csrrs_instruction(&mut self) -> bool {
-        self.get_opcode() == Self::OPCODE_CSR && self.get_funct3() == Self::FUNCT3_CSRRS
+        self.get_opcode() == Self::OPCODE_SYSTEM && self.get_funct3() == Self::FUNCT3_CSRRS
     }
 
     pub fn is_compression_instruction(&mut self) -> bool {

--- a/hypervisor.ld
+++ b/hypervisor.ld
@@ -28,7 +28,7 @@ SECTIONS
 
   .intr_stack (NOLOAD) : {
     _intr_stack_start = .;
-    . = . + 0x2000;
+    . = . + 0x4000;
     _intr_stack_end = .;
   }
 

--- a/hypervisor/src/emulate_csr.rs
+++ b/hypervisor/src/emulate_csr.rs
@@ -46,7 +46,7 @@ impl HypervisorCsr {
         }
     }
 
-    pub fn get_csr(&mut self, csr_address: usize) -> u64 {
+    pub fn get_csr(&self, csr_address: usize) -> u64 {
         match csr_address {
             CSR_TIME_ADDRESS => get_time(),
             CSR_HSTATUS_ADDRESS => self.hstatus,
@@ -72,7 +72,7 @@ impl HypervisorCsr {
     pub fn set_csr(&mut self, csr_address: usize, value: u64) {
         match csr_address {
             CSR_TIME_ADDRESS => {
-                get_time(); // this register is read only.
+                panic!("Attempted to write to read-only CSR_TIME_ADDRESS register");
             }
             CSR_HSTATUS_ADDRESS => {
                 self.hstatus = value;

--- a/hypervisor/src/emulate_csr.rs
+++ b/hypervisor/src/emulate_csr.rs
@@ -1,0 +1,26 @@
+use arch::riscv::{cpu::{csr_address::*, get_time}, instruction::Instruction};
+
+pub fn emulate_csr(csr_number: usize, instruction: Instruction registers: &mut [u64]) {
+    match csr_number {
+        CSR_TIME_ADDRESS => {
+            let register_number = instruction.get_rd();
+            registers[register_number] = get_time();
+        }
+        CSR_HSTATUS_ADDRESS => {},
+        CSR_HEDELEG_ADDRESS => {},
+        CSR_HIE_ADDRESS => {},
+        CSR_HCOUNTEREN_ADDRESS => {},
+        CSR_HGEIE_ADDRESS => {},
+        CSR_HTVAL_ADDRESS => {},
+        CSR_HIP_ADDRESS => {}, 
+        CSR_HVIP_ADDRESS => {},
+        CSR_HTINST_ADDRESS => {},
+        CSR_HGEIP_ADDRESS => {},
+        CSR_HENVCFG_ADDRESS => {},
+        CSR_HGATP_ADDRESS => {},
+        _ => {
+            println!("This csr number isn't supported: {:#x}", csr_number);
+            panic!();
+        }
+    }
+}

--- a/hypervisor/src/emulate_csr.rs
+++ b/hypervisor/src/emulate_csr.rs
@@ -1,26 +1,155 @@
-use arch::riscv::{cpu::{csr_address::*, get_time}, instruction::Instruction};
+use arch::riscv::cpu::{csr_address::*, get_time};
+use spin::Mutex;
+use crate::println;
 
-pub fn emulate_csr(csr_number: usize, instruction: Instruction registers: &mut [u64]) {
-    match csr_number {
-        CSR_TIME_ADDRESS => {
-            let register_number = instruction.get_rd();
-            registers[register_number] = get_time();
-        }
-        CSR_HSTATUS_ADDRESS => {},
-        CSR_HEDELEG_ADDRESS => {},
-        CSR_HIE_ADDRESS => {},
-        CSR_HCOUNTEREN_ADDRESS => {},
-        CSR_HGEIE_ADDRESS => {},
-        CSR_HTVAL_ADDRESS => {},
-        CSR_HIP_ADDRESS => {}, 
-        CSR_HVIP_ADDRESS => {},
-        CSR_HTINST_ADDRESS => {},
-        CSR_HGEIP_ADDRESS => {},
-        CSR_HENVCFG_ADDRESS => {},
-        CSR_HGATP_ADDRESS => {},
-        _ => {
-            println!("This csr number isn't supported: {:#x}", csr_number);
-            panic!();
+pub struct VirtualCsr {
+    pub hstatus: u64,
+    pub hedeleg: u64,
+    pub hideleg: u64,
+    pub hie: u64,
+    pub hcounteren: u64,
+    pub hgeie: u64,
+    pub htval: u64,
+    pub hip: u64,
+    pub hvip: u64,
+    pub htinst: u64,
+    pub hgeip: u64,
+    pub henvcfg: u64,
+    pub hgatp: u64,
+}
+
+impl Default for VirtualCsr {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VirtualCsr {
+    pub const fn new() -> Self {
+        VirtualCsr {
+            hstatus: 0,
+            hedeleg: 0,
+            hideleg: 0,
+            hie: 0,
+            hcounteren: 0,
+            hgeie: 0,
+            htval: 0,
+            hip: 0,
+            hvip: 0,
+            htinst: 0,
+            hgeip: 0,
+            henvcfg: 0,
+            hgatp: 0,
         }
     }
+
+    pub fn get_csr(&mut self, csr_address: usize) -> u64 {
+        match csr_address {
+            CSR_TIME_ADDRESS => {
+                get_time()
+            }
+            CSR_HSTATUS_ADDRESS => {
+                self.hstatus
+            },
+            CSR_HEDELEG_ADDRESS => {
+                self.hedeleg
+            },
+            CSR_HIDELEG_ADDRESS => {
+                self.hideleg
+            },
+            CSR_HIE_ADDRESS => {
+                self.hie
+            },
+            CSR_HCOUNTEREN_ADDRESS => {
+                self.hcounteren
+            },
+            CSR_HGEIE_ADDRESS => {
+                self.hgeie
+            },
+            CSR_HTVAL_ADDRESS => {
+                self.htval
+            },
+            CSR_HIP_ADDRESS => {
+                self.hip
+            }, 
+            CSR_HVIP_ADDRESS => {
+                self.hvip
+            },
+            CSR_HTINST_ADDRESS => {
+                self.htinst
+            },
+            CSR_HGEIP_ADDRESS => {
+                self.hgeip
+            },
+            CSR_HENVCFG_ADDRESS => {
+                self.henvcfg
+            },
+            CSR_HGATP_ADDRESS => {
+                self.hgatp
+            },
+            _ => {
+                println!("This csr number isn't supported: {:#x}", csr_address);
+                panic!();
+            }
+        }
+    }
+
+    pub fn set_csr(&mut self, csr_address: usize, value: u64) {
+        match csr_address {
+            CSR_TIME_ADDRESS => {
+                get_time(); // this register is read only.
+            }
+            CSR_HSTATUS_ADDRESS => {
+                self.hstatus = value;
+            },
+            CSR_HEDELEG_ADDRESS => {
+                self.hedeleg = value;
+            },
+            CSR_HIDELEG_ADDRESS => {
+                self.hideleg = value;
+            },
+            CSR_HIE_ADDRESS => {
+                self.hie = value;
+            },
+            CSR_HCOUNTEREN_ADDRESS => {
+                self.hcounteren = value;
+            },
+            CSR_HGEIE_ADDRESS => {
+                self.hgeie = value;
+            },
+            CSR_HTVAL_ADDRESS => {
+                self.htval = value;
+            },
+            CSR_HIP_ADDRESS => {
+                self.hip = value;
+            }, 
+            CSR_HVIP_ADDRESS => {
+                self.hvip = value;
+            },
+            CSR_HTINST_ADDRESS => {
+                self.htinst = value;
+            },
+            CSR_HGEIP_ADDRESS => {
+                self.hgeip = value;
+            },
+            CSR_HENVCFG_ADDRESS => {
+                self.henvcfg = value;
+            },
+            CSR_HGATP_ADDRESS => {
+                self.hgatp = value;
+            },
+            _ => {
+                println!("This csr number isn't supported: {:#x}", csr_address);
+                panic!();
+            }
+        }
+    }
+
+}
+
+pub static VIRTUAL_CSR: Mutex<VirtualCsr> = Mutex::new(VirtualCsr::new());
+
+pub fn emulate_csr(csr_address: usize, rd: usize, write_value: u64, registers: &mut [u64]) {
+    registers[rd] = VIRTUAL_CSR.lock().get_csr(csr_address);
+    VIRTUAL_CSR.lock().set_csr(csr_address, write_value);
 }

--- a/hypervisor/src/emulate_csr.rs
+++ b/hypervisor/src/emulate_csr.rs
@@ -1,6 +1,6 @@
+use crate::println;
 use arch::riscv::cpu::{csr_address::*, get_time};
 use spin::Mutex;
-use crate::println;
 
 pub struct VirtualCsr {
     pub hstatus: u64,
@@ -45,48 +45,20 @@ impl VirtualCsr {
 
     pub fn get_csr(&mut self, csr_address: usize) -> u64 {
         match csr_address {
-            CSR_TIME_ADDRESS => {
-                get_time()
-            }
-            CSR_HSTATUS_ADDRESS => {
-                self.hstatus
-            },
-            CSR_HEDELEG_ADDRESS => {
-                self.hedeleg
-            },
-            CSR_HIDELEG_ADDRESS => {
-                self.hideleg
-            },
-            CSR_HIE_ADDRESS => {
-                self.hie
-            },
-            CSR_HCOUNTEREN_ADDRESS => {
-                self.hcounteren
-            },
-            CSR_HGEIE_ADDRESS => {
-                self.hgeie
-            },
-            CSR_HTVAL_ADDRESS => {
-                self.htval
-            },
-            CSR_HIP_ADDRESS => {
-                self.hip
-            }, 
-            CSR_HVIP_ADDRESS => {
-                self.hvip
-            },
-            CSR_HTINST_ADDRESS => {
-                self.htinst
-            },
-            CSR_HGEIP_ADDRESS => {
-                self.hgeip
-            },
-            CSR_HENVCFG_ADDRESS => {
-                self.henvcfg
-            },
-            CSR_HGATP_ADDRESS => {
-                self.hgatp
-            },
+            CSR_TIME_ADDRESS => get_time(),
+            CSR_HSTATUS_ADDRESS => self.hstatus,
+            CSR_HEDELEG_ADDRESS => self.hedeleg,
+            CSR_HIDELEG_ADDRESS => self.hideleg,
+            CSR_HIE_ADDRESS => self.hie,
+            CSR_HCOUNTEREN_ADDRESS => self.hcounteren,
+            CSR_HGEIE_ADDRESS => self.hgeie,
+            CSR_HTVAL_ADDRESS => self.htval,
+            CSR_HIP_ADDRESS => self.hip,
+            CSR_HVIP_ADDRESS => self.hvip,
+            CSR_HTINST_ADDRESS => self.htinst,
+            CSR_HGEIP_ADDRESS => self.hgeip,
+            CSR_HENVCFG_ADDRESS => self.henvcfg,
+            CSR_HGATP_ADDRESS => self.hgatp,
             _ => {
                 println!("This csr number isn't supported: {:#x}", csr_address);
                 panic!();
@@ -101,50 +73,49 @@ impl VirtualCsr {
             }
             CSR_HSTATUS_ADDRESS => {
                 self.hstatus = value;
-            },
+            }
             CSR_HEDELEG_ADDRESS => {
                 self.hedeleg = value;
-            },
+            }
             CSR_HIDELEG_ADDRESS => {
                 self.hideleg = value;
-            },
+            }
             CSR_HIE_ADDRESS => {
                 self.hie = value;
-            },
+            }
             CSR_HCOUNTEREN_ADDRESS => {
                 self.hcounteren = value;
-            },
+            }
             CSR_HGEIE_ADDRESS => {
                 self.hgeie = value;
-            },
+            }
             CSR_HTVAL_ADDRESS => {
                 self.htval = value;
-            },
+            }
             CSR_HIP_ADDRESS => {
                 self.hip = value;
-            }, 
+            }
             CSR_HVIP_ADDRESS => {
                 self.hvip = value;
-            },
+            }
             CSR_HTINST_ADDRESS => {
                 self.htinst = value;
-            },
+            }
             CSR_HGEIP_ADDRESS => {
                 self.hgeip = value;
-            },
+            }
             CSR_HENVCFG_ADDRESS => {
                 self.henvcfg = value;
-            },
+            }
             CSR_HGATP_ADDRESS => {
                 self.hgatp = value;
-            },
+            }
             _ => {
                 println!("This csr number isn't supported: {:#x}", csr_address);
                 panic!();
             }
         }
     }
-
 }
 
 pub static VIRTUAL_CSR: Mutex<VirtualCsr> = Mutex::new(VirtualCsr::new());

--- a/hypervisor/src/emulate_csr.rs
+++ b/hypervisor/src/emulate_csr.rs
@@ -1,5 +1,7 @@
 use crate::println;
-use arch::riscv::cpu::{csr_address::*, get_time};
+use crate::paging::resolve_address_stage2_from_hgatp;
+use arch::riscv::cpu::csr_address::*;
+use arch::riscv::cpu::*;
 use spin::Mutex;
 
 pub struct VirtualCsr {
@@ -109,6 +111,18 @@ impl VirtualCsr {
             }
             CSR_HGATP_ADDRESS => {
                 self.hgatp = value;
+
+                let original_mstatus = get_mstatus();
+                let mut mstatus = original_mstatus;
+                mstatus |= MSTATUS_MPRV as u64;
+                mstatus |= MSTATUS_MPV as u64;
+                mstatus |= MSTATUS_MPP_0 as u64;
+                mstatus &= !(MSTATUS_MPP_1 as u64);
+                set_mstatus(mstatus);
+                let address = resolve_address_stage2_from_hgatp(value, 0x80000000).expect("l1 page table error");
+                println!("Guest Physical Address: {:#x}", address);
+                set_mstatus(original_mstatus);
+                panic!();
             }
             _ => {
                 println!("This csr number isn't supported: {:#x}", csr_address);

--- a/hypervisor/src/emulate_csr.rs
+++ b/hypervisor/src/emulate_csr.rs
@@ -1,5 +1,5 @@
 use crate::println;
-use crate::paging::resolve_address_stage2_from_hgatp;
+use crate::paging::resolve_guest_virtual_address_stage2;
 use arch::riscv::cpu::csr_address::*;
 use arch::riscv::cpu::*;
 use spin::Mutex;
@@ -112,16 +112,11 @@ impl VirtualCsr {
             CSR_HGATP_ADDRESS => {
                 self.hgatp = value;
 
-                let original_mstatus = get_mstatus();
-                let mut mstatus = original_mstatus;
-                mstatus |= MSTATUS_MPRV as u64;
-                mstatus |= MSTATUS_MPV as u64;
-                mstatus |= MSTATUS_MPP_0 as u64;
-                mstatus &= !(MSTATUS_MPP_1 as u64);
-                set_mstatus(mstatus);
-                let address = resolve_address_stage2_from_hgatp(value, 0x80000000).expect("l1 page table error");
-                println!("Guest Physical Address: {:#x}", address);
-                set_mstatus(original_mstatus);
+                let sample_gva = 0x80000000;
+                println!("sample_gva: {:#x}", sample_gva);
+                let sample_gpa = resolve_guest_virtual_address_stage2(sample_gva).unwrap();
+                println!("{:#x} => {:#x}", sample_gva, sample_gpa);
+
                 panic!();
             }
             _ => {

--- a/hypervisor/src/emulate_csr.rs
+++ b/hypervisor/src/emulate_csr.rs
@@ -1,5 +1,5 @@
+use crate::paging::shadow_map_address_stage2;
 use crate::println;
-use crate::paging::resolve_guest_virtual_address_stage2;
 use arch::riscv::cpu::csr_address::*;
 use arch::riscv::cpu::*;
 use spin::Mutex;
@@ -127,8 +127,6 @@ pub fn emulate_csr(csr_address: usize, rd: usize, write_value: u64, registers: &
     VIRTUAL_CSR.lock().set_csr(csr_address, write_value);
 
     if csr_address == CSR_HGATP_ADDRESS {
-        let sample_gva = 0x80000000;
-        let sample_gpa = resolve_guest_virtual_address_stage2(sample_gva).unwrap();
-        println!("{:#x} => {:#x}", sample_gva, sample_gpa);
+        let _ = shadow_map_address_stage2(true, true, true);
     }
 }

--- a/hypervisor/src/emulate_csr.rs
+++ b/hypervisor/src/emulate_csr.rs
@@ -4,6 +4,7 @@ use arch::riscv::cpu::csr_address::*;
 use arch::riscv::cpu::*;
 use spin::Mutex;
 
+#[derive(Debug)]
 pub struct HypervisorCsr {
     pub hstatus: u64,
     pub hedeleg: u64,

--- a/hypervisor/src/emulate_csr.rs
+++ b/hypervisor/src/emulate_csr.rs
@@ -4,7 +4,7 @@ use arch::riscv::cpu::csr_address::*;
 use arch::riscv::cpu::*;
 use spin::Mutex;
 
-pub struct VirtualCsr {
+pub struct HypervisorCsr {
     pub hstatus: u64,
     pub hedeleg: u64,
     pub hideleg: u64,
@@ -20,15 +20,15 @@ pub struct VirtualCsr {
     pub hgatp: u64,
 }
 
-impl Default for VirtualCsr {
+impl Default for HypervisorCsr {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl VirtualCsr {
+impl HypervisorCsr {
     pub const fn new() -> Self {
-        VirtualCsr {
+        HypervisorCsr {
             hstatus: 0,
             hedeleg: 0,
             hideleg: 0,
@@ -120,7 +120,7 @@ impl VirtualCsr {
     }
 }
 
-pub static VIRTUAL_CSR: Mutex<VirtualCsr> = Mutex::new(VirtualCsr::new());
+pub static VIRTUAL_CSR: Mutex<HypervisorCsr> = Mutex::new(HypervisorCsr::new());
 
 pub fn emulate_csr(csr_address: usize, rd: usize, write_value: u64, registers: &mut [u64]) {
     registers[rd] = VIRTUAL_CSR.lock().get_csr(csr_address);

--- a/hypervisor/src/emulate_csr.rs
+++ b/hypervisor/src/emulate_csr.rs
@@ -111,13 +111,6 @@ impl VirtualCsr {
             }
             CSR_HGATP_ADDRESS => {
                 self.hgatp = value;
-
-                let sample_gva = 0x80000000;
-                println!("sample_gva: {:#x}", sample_gva);
-                let sample_gpa = resolve_guest_virtual_address_stage2(sample_gva).unwrap();
-                println!("{:#x} => {:#x}", sample_gva, sample_gpa);
-
-                panic!();
             }
             _ => {
                 println!("This csr number isn't supported: {:#x}", csr_address);
@@ -132,4 +125,10 @@ pub static VIRTUAL_CSR: Mutex<VirtualCsr> = Mutex::new(VirtualCsr::new());
 pub fn emulate_csr(csr_address: usize, rd: usize, write_value: u64, registers: &mut [u64]) {
     registers[rd] = VIRTUAL_CSR.lock().get_csr(csr_address);
     VIRTUAL_CSR.lock().set_csr(csr_address, write_value);
+
+    if csr_address == CSR_HGATP_ADDRESS {
+        let sample_gva = 0x80000000;
+        let sample_gpa = resolve_guest_virtual_address_stage2(sample_gva).unwrap();
+        println!("{:#x} => {:#x}", sample_gva, sample_gpa);
+    }
 }

--- a/hypervisor/src/main.rs
+++ b/hypervisor/src/main.rs
@@ -178,7 +178,7 @@ extern "C" fn main(argc: usize, argv: *const *const u8) -> usize {
     setup_vector();
     println!("[setup] mtvec");
     println!("[setup] stvec");
-    
+
     let mut medeleg = get_medeleg();
     medeleg |= (1 << 20) as u64;
     medeleg |= (1 << 12) as u64;
@@ -269,7 +269,6 @@ extern "C" fn main(argc: usize, argv: *const *const u8) -> usize {
 }
 
 fn hs_to_vs(vs_entry_point: usize, vs_stack_pointer: usize, dtb_pointer: usize) -> ! {
-
     let mut hstatus = get_hstatus();
     hstatus |= HSTATUS_SPV as u64;
     set_hstatus(hstatus);

--- a/hypervisor/src/main.rs
+++ b/hypervisor/src/main.rs
@@ -27,6 +27,8 @@ use core::alloc::{GlobalAlloc, Layout};
 use core::arch::asm;
 use core::mem::MaybeUninit;
 use core::ptr::NonNull;
+#[cfg(feature = "nested_support")]
+use crate::emulate_csr::HypervisorCsr;
 use fdt::DeviceTreeInfo;
 use log;
 use memory::set_pmp_all_physical_address;
@@ -76,6 +78,8 @@ static PASS_THROUGH_VIRTIO_MMIO: Mutex<MaybeUninit<VirtioMmio>> =
 static PASS_THROUGH_VIRTIO_BLK_DEVICE: Mutex<MaybeUninit<virtio_blk::VirtioBlk>> =
     Mutex::new(MaybeUninit::<virtio_blk::VirtioBlk>::uninit());
 static VIRTUAL_UART_DEVICE: Mutex<Uart> = Mutex::new(Uart::new());
+#[cfg(feature = "nested_support")]
+static HOST_HYPERVISOR_CSR: Mutex<HypervisorCsr> = Mutex::new(HypervisorCsr::new());
 
 #[global_allocator]
 static GLOBAL_ALLOCATOR: GlobalAllocator = GlobalAllocator {};

--- a/hypervisor/src/main.rs
+++ b/hypervisor/src/main.rs
@@ -178,11 +178,7 @@ extern "C" fn main(argc: usize, argv: *const *const u8) -> usize {
     setup_vector();
     println!("[setup] mtvec");
     println!("[setup] stvec");
-
-    // let mut mstatus = get_mstatus();
-    // mstatus |= (1 << MSTATUS_TVM_OFFSET) as u64;
-    // set_mstatus(mstatus);
-
+    
     let mut medeleg = get_medeleg();
     medeleg |= (1 << 20) as u64;
     medeleg |= (1 << 12) as u64;
@@ -227,6 +223,10 @@ extern "C" fn main(argc: usize, argv: *const *const u8) -> usize {
     mstatus |= MSTATUS_MIE as u64;
     set_mstatus(mstatus);
 
+    let mut hstatus = get_hstatus();
+    hstatus |= HSTATUS_VSTR as u64;
+    set_hstatus(hstatus);
+
     // 仮想マシンの領域のPMPを設定する;
     // let top_address = 0xF0000000 as usize;
     // let bottom_address = 0x80000000 as usize;
@@ -269,16 +269,20 @@ extern "C" fn main(argc: usize, argv: *const *const u8) -> usize {
 }
 
 fn hs_to_vs(vs_entry_point: usize, vs_stack_pointer: usize, dtb_pointer: usize) -> ! {
+
+    let mut hstatus = get_hstatus();
+    hstatus |= HSTATUS_SPV as u64;
+    set_hstatus(hstatus);
+    let mut sstatus = get_sstatus();
+    sstatus |= SSTATUS_SPP as u64;
+    set_sstatus(sstatus);
+
     unsafe {
         asm!("
-            csrs sstatus, {tmp1}
-            csrs hstatus, {tmp2}
             csrw sepc, {entry_point}
             mv sp, {stack_pointer}
             mv a1, {dtb_pointer}
             sret", 
-        tmp1 = in(reg) 0x100, // set sstatus.SPP
-        tmp2 = in(reg) 0x80, // set hstatus.SPV
         stack_pointer = in(reg) vs_stack_pointer,
         entry_point = in(reg) vs_entry_point,
         dtb_pointer = in(reg) dtb_pointer,

--- a/hypervisor/src/main.rs
+++ b/hypervisor/src/main.rs
@@ -12,6 +12,7 @@ mod paging;
 mod plic;
 mod sbi;
 mod vector;
+#[cfg(feature = "nested_support")]
 mod emulate_csr;
 mod virtio_blk;
 mod vm;

--- a/hypervisor/src/main.rs
+++ b/hypervisor/src/main.rs
@@ -6,14 +6,14 @@ extern crate alloc;
 
 mod aplic;
 mod console;
+#[cfg(feature = "nested_support")]
+mod emulate_csr;
 mod loader;
 mod memory;
 mod paging;
 mod plic;
 mod sbi;
 mod vector;
-#[cfg(feature = "nested_support")]
-mod emulate_csr;
 mod virtio_blk;
 mod vm;
 mod mmio {

--- a/hypervisor/src/main.rs
+++ b/hypervisor/src/main.rs
@@ -88,6 +88,13 @@ unsafe impl GlobalAlloc for GlobalAllocator {
         }
     }
 
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        match MEMORY_ALLOCATOR.lock().callocate(layout) {
+            Ok(ptr) => ptr.as_ptr(),
+            Err(_) => core::ptr::null_mut(),
+        }
+    }
+
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         unsafe {
             MEMORY_ALLOCATOR

--- a/hypervisor/src/main.rs
+++ b/hypervisor/src/main.rs
@@ -21,14 +21,14 @@ mod mmio {
     pub mod virtio;
 }
 
+#[cfg(feature = "nested_support")]
+use crate::emulate_csr::HypervisorCsr;
 use alloc::vec::Vec;
 use arch::riscv::cpu::*;
 use core::alloc::{GlobalAlloc, Layout};
 use core::arch::asm;
 use core::mem::MaybeUninit;
 use core::ptr::NonNull;
-#[cfg(feature = "nested_support")]
-use crate::emulate_csr::HypervisorCsr;
 use fdt::DeviceTreeInfo;
 use log;
 use memory::set_pmp_all_physical_address;

--- a/hypervisor/src/main.rs
+++ b/hypervisor/src/main.rs
@@ -12,6 +12,7 @@ mod paging;
 mod plic;
 mod sbi;
 mod vector;
+mod emulate_csr;
 mod virtio_blk;
 mod vm;
 mod mmio {

--- a/hypervisor/src/memory.rs
+++ b/hypervisor/src/memory.rs
@@ -17,6 +17,17 @@ pub fn allocate_pages(num_of_pages: usize, align: usize) -> *mut u8 {
 }
 
 #[allow(dead_code)]
+pub fn callocate_pages(num_of_pages: usize, align: usize) -> *mut u8 {
+    let layout =
+        unsafe { Layout::from_size_align_unchecked(num_of_pages * paging::PAGE_SIZE, align) };
+
+    match MEMORY_ALLOCATOR.lock().callocate(layout) {
+        Ok(ptr) => ptr.as_ptr(),
+        Err(_) => core::ptr::null_mut(),
+    }
+}
+
+#[allow(dead_code)]
 pub fn set_pmp(
     top_address: usize,
     bottom_address: usize,

--- a/hypervisor/src/paging.rs
+++ b/hypervisor/src/paging.rs
@@ -2,6 +2,8 @@ use core::borrow::BorrowMut;
 
 use crate::memory::allocate_pages;
 use crate::println;
+#[cfg(feature="nested_support")]
+use crate::emulate_csr::VIRTUAL_CSR;
 use arch::riscv::cpu::*;
 
 pub const DEFAULT_TABLE_LEVEL: i8 = 4;
@@ -39,12 +41,16 @@ impl TableEntry {
         *self = Self::new();
     }
 
-    pub fn get_next_table_address(&mut self) -> usize {
+    pub fn get_next_table_address(&self) -> usize {
         (((self.0 & Self::PPN_MASK as u64) >> Self::PPN_OFFSET as u64) << PAGE_SHIFT) as usize
     }
 
     pub fn set_output_address(&mut self, address: usize) {
         self.0 |= (((address >> PAGE_SHIFT) << Self::PPN_OFFSET) & Self::PPN_MASK) as u64;
+    }
+
+    pub fn get_permission(&self) -> u64 {
+        self.0 & Self::PERMISSION_MASK as u64
     }
 
     pub fn set_permission(&mut self, permission: u64) {
@@ -56,7 +62,7 @@ impl TableEntry {
         self.0 &= !((1 << Self::R_OFFSET) | (1 << Self::X_OFFSET)) as u64;
     }
 
-    pub fn is_valid_pte(&mut self) -> bool {
+    pub fn is_valid_pte(&self) -> bool {
         (self.0 & (1 << Self::V_OFFSET)) != 0
     }
 }
@@ -118,6 +124,68 @@ pub fn resolve_address_stage2(virtual_address: usize) -> Result<usize, ()> {
         top_level_stage_2_num_of_entries,
     )?;
     Ok(physical_address)
+}
+
+fn _resolve_guest_virtual_address_stage2(
+    virtual_address: usize,
+    table_address: usize,
+    table_level: i8,
+    num_of_entries: usize,
+) -> Result<usize, ()> {
+    let shift_level = 12 + 9 * table_level as usize;
+    let table_index = (virtual_address >> shift_level) & (num_of_entries - 1);
+    
+    let pte_address = table_address + table_index * core::mem::size_of::<TableEntry>();
+    let mut pte: TableEntry;
+    asm!(
+        "hlv.d {0}, {1}",
+        out(reg) pte,
+        in(reg) pte_address
+    );
+    if !pte.is_valid_pte() {
+        return Err(());
+    }
+
+    if table_level == 0 {
+        let offset = virtual_address & ((1 << PAGE_SHIFT) - 1);
+        return Ok(pte.get_next_table_address() + offset);
+    }
+
+    let next_table_address = pte.get_next_table_address();
+    _resolve_guest_virtual_address_stage2(
+        virtual_address,
+        next_table_address,
+        table_level - 1,
+        (1 << VPN_SIZE) as usize,
+    )
+}
+
+pub fn resolve_guest_virtual_address_stage2(virtual_address: usize) -> Result<usize, ()> {
+    let hgatp = VIRTUAL_CSR.lock().hgatp;
+    let table_address = ((hgatp & SATP_PPN_MASK as u64) << 12) as usize;
+    let mode = ((hgatp & SATP_MODE_MASK as u64) >> 60) as usize;
+
+    let table_level: i8 = match mode {
+        0 => {
+            println!("Bare mode");
+            return Err(());
+        }
+        8 => 3,
+        9 => 4,
+        10 => 5,
+        _ => unreachable!(),
+    };
+
+    let top_level_stage_2_num_of_entries = 1 << G_STAGE_TOP_VPN_SIZE;
+
+    let physical_address = _resolve_guest_virtual_address_stage2(
+        virtual_address,
+        table_address,
+        table_level - 1,
+        top_level_stage_2_num_of_entries,
+    )?;
+    Ok(physical_address)
+
 }
 
 fn _map_address_stage2(
@@ -228,6 +296,114 @@ pub fn map_address_stage2(
         &mut physical_address,
         &mut virtual_address,
         &mut map_size,
+        table_address,
+        permission,
+        table_level - 1,
+        top_level_stage_2_num_of_entries,
+    );
+
+    Ok(table_address as usize)
+}
+
+#[cfg(feature = "nested_support")]
+fn _shadow_map_address_stage2(
+    l1_table_address: usize,
+    table_address: usize,
+    permission: u64,
+    table_level: i8,
+    num_of_entries: usize,
+) -> Result<(), ()> {
+    let l1_table = unsafe {
+        &mut *core::ptr::slice_from_raw_parts_mut(l1_table_address as *mut TableEntry, num_of_entries)
+    };
+    let table = unsafe {
+        &mut *core::ptr::slice_from_raw_parts_mut(table_address as *mut TableEntry, num_of_entries)
+    };
+
+    if table_level == 0 {
+        for (i, e) in table[0..num_of_entries].iter_mut().enumerate() {
+            let l1_entry = &l1_table[i];
+            let guest_physical_address = l1_entry.get_next_table_address();
+            let physical_address = resolve_address_stage2(guest_physical_address).unwrap();
+            e.init();
+            e.set_output_address(physical_address);
+            e.set_permission(
+                permission | (1 << TableEntry::V_OFFSET) | (1 << TableEntry::U_OFFSET),
+            );
+        }
+        return Ok(());
+    }
+
+    for (i, e) in table[0..num_of_entries].iter_mut().enumerate() {
+        let l1_entry = &l1_table[i];
+        let permission = l1_entry.get_permission();
+        if !l1_entry.is_valid_pte() {
+            continue; 
+        }
+        e.init();
+        let mut next_l1_table_address = e.get_next_table_address();
+        if !e.is_valid_pte() {
+            let new_l1_table_address = allocate_pages(1, PAGE_SIZE);
+            if new_l1_table_address.is_null() {
+                println!("Failed to allocate pages for stage2 page table.");
+                return Err(());
+            }
+            next_l1_table_address = new_l1_table_address as usize;
+            e.set_output_address(next_l1_table_address);
+            e.set_non_leaf_permission();
+        }
+
+        let _ = _shadow_map_address_stage2(
+            next_l1_table_address,
+            next_l1_table_address,
+            permission,
+            table_level - 1,
+            (1 << VPN_SIZE) as usize,
+        );
+    }
+    Ok(())
+}
+
+#[cfg(feature = "nested_support")]
+pub fn shadow_map_address_stage2(
+    table_level: i8,
+    is_readable: bool,
+    is_writable: bool,
+    is_executable: bool,
+) -> Result<usize, ()> {
+    let vhgatp = VIRTUAL_CSR.lock().hgatp;
+    let l1_table_guest_physical_address = ((vhgatp & SATP_PPN_MASK as u64) << 12) as usize;
+    let l1_table_address = resolve_address_stage2(l1_table_guest_physical_address).unwrap();
+
+    let table_address_ptr = allocate_pages(4, 1 << 14);
+    if table_address_ptr.is_null() {
+        println!("Failed to allocate pages for stage 2 page table.");
+        return Err(());
+    }
+    let table_address = table_address_ptr as usize;
+
+    let top_level_stage_2_num_of_entries = 1 << G_STAGE_TOP_VPN_SIZE;
+
+    let mut permission: u64 = if is_readable {
+        (1 << TableEntry::R_OFFSET) as u64
+    } else {
+        0
+    };
+
+    permission |= if is_writable {
+        (1 << TableEntry::W_OFFSET) as u64
+    } else {
+        0
+    };
+
+    permission |= if is_executable {
+        (1 << TableEntry::X_OFFSET) as u64
+    } else {
+        0
+    };
+
+    let _ = _shadow_map_address_stage2(
+        l1_table_address,
         table_address,
         permission,
         table_level - 1,

--- a/hypervisor/src/paging.rs
+++ b/hypervisor/src/paging.rs
@@ -5,6 +5,7 @@ use crate::println;
 #[cfg(feature="nested_support")]
 use crate::emulate_csr::VIRTUAL_CSR;
 use arch::riscv::cpu::*;
+use arch::riscv::instruction::*;
 
 pub const DEFAULT_TABLE_LEVEL: i8 = 4;
 pub const VPN_SIZE: i8 = 9;
@@ -126,6 +127,7 @@ pub fn resolve_address_stage2(virtual_address: usize) -> Result<usize, ()> {
     Ok(physical_address)
 }
 
+#[cfg(feature = "nested_support")]
 fn _resolve_guest_virtual_address_stage2(
     virtual_address: usize,
     table_address: usize,
@@ -136,12 +138,9 @@ fn _resolve_guest_virtual_address_stage2(
     let table_index = (virtual_address >> shift_level) & (num_of_entries - 1);
     
     let pte_address = table_address + table_index * core::mem::size_of::<TableEntry>();
-    let mut pte: TableEntry;
-    asm!(
-        "hlv.d {0}, {1}",
-        out(reg) pte,
-        in(reg) pte_address
-    );
+    let value = read_vm_memory(false, pte_address, 64);
+    let mut pte = TableEntry::new();
+    pte.0 = value;
     if !pte.is_valid_pte() {
         return Err(());
     }
@@ -160,10 +159,14 @@ fn _resolve_guest_virtual_address_stage2(
     )
 }
 
+#[cfg(feature = "nested_support")]
 pub fn resolve_guest_virtual_address_stage2(virtual_address: usize) -> Result<usize, ()> {
+    println!("virtual_address: {:#x}", virtual_address);
     let hgatp = VIRTUAL_CSR.lock().hgatp;
+    println!("virtual hgatp: {:#x}", hgatp);
     let table_address = ((hgatp & SATP_PPN_MASK as u64) << 12) as usize;
     let mode = ((hgatp & SATP_MODE_MASK as u64) >> 60) as usize;
+
 
     let table_level: i8 = match mode {
         0 => {

--- a/hypervisor/src/paging.rs
+++ b/hypervisor/src/paging.rs
@@ -161,12 +161,9 @@ fn _resolve_guest_virtual_address_stage2(
 
 #[cfg(feature = "nested_support")]
 pub fn resolve_guest_virtual_address_stage2(virtual_address: usize) -> Result<usize, ()> {
-    println!("virtual_address: {:#x}", virtual_address);
     let hgatp = VIRTUAL_CSR.lock().hgatp;
-    println!("virtual hgatp: {:#x}", hgatp);
     let table_address = ((hgatp & SATP_PPN_MASK as u64) << 12) as usize;
     let mode = ((hgatp & SATP_MODE_MASK as u64) >> 60) as usize;
-
 
     let table_level: i8 = match mode {
         0 => {

--- a/hypervisor/src/paging.rs
+++ b/hypervisor/src/paging.rs
@@ -300,7 +300,7 @@ fn _shadow_map_address_stage2(
 ) -> Result<(), ()> {
     if table_level == -1 {
         let guest_physical_address = table_address;
-        let physical_address = resolve_address_stage2(guest_physical_address).unwrap();
+        let physical_address = resolve_address_stage2(guest_physical_address)?;
 
         let shadow_table_address = SHADOW_ROOT_PAGE_TABLE.load(Ordering::Acquire);
         add_mapping_stage2(
@@ -309,11 +309,10 @@ fn _shadow_map_address_stage2(
             PAGE_SIZE,
             shadow_table_address as usize,
             DEFAULT_TABLE_LEVEL,
-            true,
-            true,
-            true,
-        )
-        .unwrap();
+            (permission & (1 << TableEntry::R_OFFSET)) != 0,
+            (permission & (1 << TableEntry::W_OFFSET)) != 0,
+            (permission & (1 << TableEntry::X_OFFSET)) != 0,
+        )?;
 
         return Ok(());
     }
@@ -321,12 +320,10 @@ fn _shadow_map_address_stage2(
     let shift_level = 12 + 9 * table_level as usize;
     for i in 0..num_of_entries {
         let pte_address = table_address + i * core::mem::size_of::<TableEntry>();
-        if table_level == 0 {}
         let value = read_vm_memory(false, pte_address, 64);
         let mut pte = TableEntry::new();
         pte.0 = value;
         if !pte.is_valid_pte() {
-            if table_level != 0 {}
             continue;
         }
         *virtual_address &= !(((1 << VPN_SIZE) - 1) << shift_level);
@@ -393,13 +390,13 @@ pub fn shadow_map_address_stage2(
 
     let mut virtual_address: usize = 0;
 
-    let _ = _shadow_map_address_stage2(
+    _shadow_map_address_stage2(
         &mut virtual_address,
         l1_table_address,
         permission,
         table_level - 1,
         top_level_stage_2_num_of_entries,
-    );
+    )?;
 
     Ok(())
 }

--- a/hypervisor/src/paging.rs
+++ b/hypervisor/src/paging.rs
@@ -1,11 +1,12 @@
 use core::borrow::BorrowMut;
 
+#[cfg(feature = "nested_support")]
+use crate::emulate_csr::VIRTUAL_CSR;
 use crate::memory::allocate_pages;
 use crate::println;
-#[cfg(feature="nested_support")]
-use crate::emulate_csr::VIRTUAL_CSR;
 use arch::riscv::cpu::*;
 use arch::riscv::instruction::*;
+use core::sync::atomic::{AtomicPtr, Ordering};
 
 pub const DEFAULT_TABLE_LEVEL: i8 = 4;
 pub const VPN_SIZE: i8 = 9;
@@ -127,67 +128,6 @@ pub fn resolve_address_stage2(virtual_address: usize) -> Result<usize, ()> {
     Ok(physical_address)
 }
 
-#[cfg(feature = "nested_support")]
-fn _resolve_guest_virtual_address_stage2(
-    virtual_address: usize,
-    table_address: usize,
-    table_level: i8,
-    num_of_entries: usize,
-) -> Result<usize, ()> {
-    let shift_level = 12 + 9 * table_level as usize;
-    let table_index = (virtual_address >> shift_level) & (num_of_entries - 1);
-    
-    let pte_address = table_address + table_index * core::mem::size_of::<TableEntry>();
-    let value = read_vm_memory(false, pte_address, 64);
-    let mut pte = TableEntry::new();
-    pte.0 = value;
-    if !pte.is_valid_pte() {
-        return Err(());
-    }
-
-    if table_level == 0 {
-        let offset = virtual_address & ((1 << PAGE_SHIFT) - 1);
-        return Ok(pte.get_next_table_address() + offset);
-    }
-
-    let next_table_address = pte.get_next_table_address();
-    _resolve_guest_virtual_address_stage2(
-        virtual_address,
-        next_table_address,
-        table_level - 1,
-        (1 << VPN_SIZE) as usize,
-    )
-}
-
-#[cfg(feature = "nested_support")]
-pub fn resolve_guest_virtual_address_stage2(virtual_address: usize) -> Result<usize, ()> {
-    let hgatp = VIRTUAL_CSR.lock().hgatp;
-    let table_address = ((hgatp & SATP_PPN_MASK as u64) << 12) as usize;
-    let mode = ((hgatp & SATP_MODE_MASK as u64) >> 60) as usize;
-
-    let table_level: i8 = match mode {
-        0 => {
-            println!("Bare mode");
-            return Err(());
-        }
-        8 => 3,
-        9 => 4,
-        10 => 5,
-        _ => unreachable!(),
-    };
-
-    let top_level_stage_2_num_of_entries = 1 << G_STAGE_TOP_VPN_SIZE;
-
-    let physical_address = _resolve_guest_virtual_address_stage2(
-        virtual_address,
-        table_address,
-        table_level - 1,
-        top_level_stage_2_num_of_entries,
-    )?;
-    Ok(physical_address)
-
-}
-
 fn _map_address_stage2(
     physical_address: &mut usize,
     virtual_address: &mut usize,
@@ -305,82 +245,131 @@ pub fn map_address_stage2(
     Ok(table_address as usize)
 }
 
+pub fn add_mapping_stage2(
+    mut physical_address: usize,
+    mut virtual_address: usize,
+    mut map_size: usize,
+    table_address: usize,
+    table_level: i8,
+    is_readable: bool,
+    is_writable: bool,
+    is_executable: bool,
+) -> Result<(), ()> {
+    let top_level_stage_2_num_of_entries = 1 << G_STAGE_TOP_VPN_SIZE;
+
+    let mut permission: u64 = if is_readable {
+        (1 << TableEntry::R_OFFSET) as u64
+    } else {
+        0
+    };
+
+    permission |= if is_writable {
+        (1 << TableEntry::W_OFFSET) as u64
+    } else {
+        0
+    };
+
+    permission |= if is_executable {
+        (1 << TableEntry::X_OFFSET) as u64
+    } else {
+        0
+    };
+
+    _map_address_stage2(
+        &mut physical_address,
+        &mut virtual_address,
+        &mut map_size,
+        table_address,
+        permission,
+        table_level - 1,
+        top_level_stage_2_num_of_entries,
+    )?;
+
+    Ok(())
+}
+
+pub static SHADOW_ROOT_PAGE_TABLE: AtomicPtr<u8> = AtomicPtr::new(core::ptr::null_mut());
+
 #[cfg(feature = "nested_support")]
 fn _shadow_map_address_stage2(
-    l1_table_address: usize,
+    virtual_address: &mut usize,
     table_address: usize,
     permission: u64,
     table_level: i8,
     num_of_entries: usize,
 ) -> Result<(), ()> {
-    let l1_table = unsafe {
-        &mut *core::ptr::slice_from_raw_parts_mut(l1_table_address as *mut TableEntry, num_of_entries)
-    };
-    let table = unsafe {
-        &mut *core::ptr::slice_from_raw_parts_mut(table_address as *mut TableEntry, num_of_entries)
-    };
+    if table_level == -1 {
+        let guest_physical_address = table_address;
+        let physical_address = resolve_address_stage2(guest_physical_address).unwrap();
 
-    if table_level == 0 {
-        for (i, e) in table[0..num_of_entries].iter_mut().enumerate() {
-            let l1_entry = &l1_table[i];
-            let guest_physical_address = l1_entry.get_next_table_address();
-            let physical_address = resolve_address_stage2(guest_physical_address).unwrap();
-            e.init();
-            e.set_output_address(physical_address);
-            e.set_permission(
-                permission | (1 << TableEntry::V_OFFSET) | (1 << TableEntry::U_OFFSET),
-            );
-        }
+        let shadow_table_address = SHADOW_ROOT_PAGE_TABLE.load(Ordering::Acquire);
+        add_mapping_stage2(
+            physical_address,
+            *virtual_address,
+            PAGE_SIZE,
+            shadow_table_address as usize,
+            DEFAULT_TABLE_LEVEL,
+            true,
+            true,
+            true,
+        )
+        .unwrap();
+
         return Ok(());
     }
 
-    for (i, e) in table[0..num_of_entries].iter_mut().enumerate() {
-        let l1_entry = &l1_table[i];
-        let permission = l1_entry.get_permission();
-        if !l1_entry.is_valid_pte() {
-            continue; 
+    let shift_level = 12 + 9 * table_level as usize;
+    for i in 0..num_of_entries {
+        let pte_address = table_address + i * core::mem::size_of::<TableEntry>();
+        if table_level == 0 {}
+        let value = read_vm_memory(false, pte_address, 64);
+        let mut pte = TableEntry::new();
+        pte.0 = value;
+        if !pte.is_valid_pte() {
+            if table_level != 0 {}
+            continue;
         }
-        e.init();
-        let mut next_l1_table_address = e.get_next_table_address();
-        if !e.is_valid_pte() {
-            let new_l1_table_address = allocate_pages(1, PAGE_SIZE);
-            if new_l1_table_address.is_null() {
-                println!("Failed to allocate pages for stage2 page table.");
-                return Err(());
-            }
-            next_l1_table_address = new_l1_table_address as usize;
-            e.set_output_address(next_l1_table_address);
-            e.set_non_leaf_permission();
-        }
-
-        let _ = _shadow_map_address_stage2(
-            next_l1_table_address,
-            next_l1_table_address,
+        *virtual_address &= !(((1 << VPN_SIZE) - 1) << shift_level);
+        *virtual_address |= (i & ((1 << VPN_SIZE) - 1)) << shift_level;
+        let next_table_address = pte.get_next_table_address();
+        _shadow_map_address_stage2(
+            virtual_address,
+            next_table_address,
             permission,
             table_level - 1,
             (1 << VPN_SIZE) as usize,
-        );
+        )?;
     }
     Ok(())
 }
 
 #[cfg(feature = "nested_support")]
 pub fn shadow_map_address_stage2(
-    table_level: i8,
     is_readable: bool,
     is_writable: bool,
     is_executable: bool,
-) -> Result<usize, ()> {
-    let vhgatp = VIRTUAL_CSR.lock().hgatp;
-    let l1_table_guest_physical_address = ((vhgatp & SATP_PPN_MASK as u64) << 12) as usize;
-    let l1_table_address = resolve_address_stage2(l1_table_guest_physical_address).unwrap();
-
-    let table_address_ptr = allocate_pages(4, 1 << 14);
-    if table_address_ptr.is_null() {
-        println!("Failed to allocate pages for stage 2 page table.");
+) -> Result<(), ()> {
+    let shadow_table_address = allocate_pages(4, 1 << 14);
+    if shadow_table_address.is_null() {
+        println!("Failed to allocate pages for stage 2 shadow page table.");
         return Err(());
     }
-    let table_address = table_address_ptr as usize;
+    SHADOW_ROOT_PAGE_TABLE.store(shadow_table_address, Ordering::Release);
+
+    let vhgatp = VIRTUAL_CSR.lock().hgatp;
+    let l1_table_address = ((vhgatp & SATP_PPN_MASK as u64) << 12) as usize;
+    let mode = ((vhgatp & SATP_MODE_MASK as u64) >> 60) as usize;
+
+    let table_level: i8 = match mode {
+        0 => {
+            println!("Bare mode");
+            return Err(());
+        }
+        8 => 3,
+        9 => 4,
+        10 => 5,
+        _ => unreachable!(),
+    };
 
     let top_level_stage_2_num_of_entries = 1 << G_STAGE_TOP_VPN_SIZE;
 
@@ -402,13 +391,15 @@ pub fn shadow_map_address_stage2(
         0
     };
 
+    let mut virtual_address: usize = 0;
+
     let _ = _shadow_map_address_stage2(
+        &mut virtual_address,
         l1_table_address,
-        table_address,
         permission,
         table_level - 1,
         top_level_stage_2_num_of_entries,
     );
 
-    Ok(table_address as usize)
+    Ok(())
 }

--- a/hypervisor/src/vector.rs
+++ b/hypervisor/src/vector.rs
@@ -4,6 +4,7 @@ use crate::paging;
 use crate::plic;
 use crate::println;
 use crate::sbi;
+use crate::emulate_csr::emulate_csr;
 use arch::riscv::{cpu::*, instruction, instruction::Instruction};
 use core::arch::global_asm;
 
@@ -443,6 +444,7 @@ fn instruction_abort_handler(scause: usize, registers: &mut [u64]) {
             let mut instruction = instruction::Instruction::new(get_stval() as u32);
             if instruction.is_csrrs_instruction() {
                 let csr = instruction.get_funct12();
+                emulate_csr(csr, instruction, registers);
                 if csr == CSR_TIME_ADDRESS {
                     let register_number = instruction.get_rd();
                     registers[register_number] = get_time();

--- a/hypervisor/src/vector.rs
+++ b/hypervisor/src/vector.rs
@@ -370,10 +370,13 @@ fn instruction_abort_handler(scause: usize, registers: &mut [u64]) {
                     let write_value = registers[rs1];
                     emulate_csr(csr_address, rd, write_value, registers);
 
+                    println!("CSR: {:#x}", csr_address);
+
                     return;
                 }
 
                 println!("CSRRW: {:#x}", csr_address);
+                panic!();
             } else if instruction.is_csrrs_instruction() {
                 let csr_address = instruction.get_funct12();
                 #[cfg(feature = "nested_support")]
@@ -396,6 +399,9 @@ fn instruction_abort_handler(scause: usize, registers: &mut [u64]) {
                 }
 
                 println!("CSRRS: {:#x}", csr_address)
+            } else if instruction.is_sret() {
+                println!("sret");
+                panic!();
             } else {
                 println!("[info] VIRTUAL INSTRUCTION: {:#x}", get_stval());
                 println!("[info] virtual address: {:#x}", get_sepc());

--- a/hypervisor/src/vector.rs
+++ b/hypervisor/src/vector.rs
@@ -1,11 +1,11 @@
 use crate::PASS_THROUGH_VIRTIO_MMIO;
+#[cfg(feature = "nested_support")]
+use crate::emulate_csr::{VIRTUAL_CSR, emulate_csr};
 use crate::mmio::{ns16550, virtio, virtio::VIRTIO_MMIO_DEFAULT_ADDRESS};
 use crate::paging;
 use crate::plic;
 use crate::println;
 use crate::sbi;
-#[cfg(feature = "nested_support")]
-use crate::emulate_csr::{emulate_csr, VIRTUAL_CSR};
 use arch::riscv::cpu::csr_address::CSR_TIME_ADDRESS;
 use arch::riscv::{cpu::*, instruction, instruction::Instruction};
 use core::arch::global_asm;
@@ -453,7 +453,7 @@ fn instruction_abort_handler(scause: usize, registers: &mut [u64]) {
                     let rs1 = instruction.get_rs1();
                     let write_value = registers[rs1];
                     emulate_csr(csr_address, rd, write_value, registers);
-                    
+
                     return;
                 }
 
@@ -468,15 +468,16 @@ fn instruction_abort_handler(scause: usize, registers: &mut [u64]) {
                     let csr_value = VIRTUAL_CSR.lock().get_csr(csr_address);
                     let write_value = csr_value | reg_value;
                     emulate_csr(csr_address, rd, write_value, registers);
-                    
+
                     return;
                 }
-                if csr_address == CSR_TIME_ADDRESS { // Read Only
+                if csr_address == CSR_TIME_ADDRESS {
+                    // Read Only
                     let rd = instruction.get_rd();
                     registers[rd] = get_time();
 
                     return;
-                } 
+                }
 
                 println!("CSRRS: {:#x}", csr_address)
             } else {

--- a/hypervisor/src/vector.rs
+++ b/hypervisor/src/vector.rs
@@ -1,6 +1,9 @@
 use crate::PASS_THROUGH_VIRTIO_MMIO;
 #[cfg(feature = "nested_support")]
-use crate::emulate_csr::{VIRTUAL_CSR, emulate_csr};
+use {
+    crate::emulate_csr::{HypervisorCsr, VIRTUAL_CSR, emulate_csr},
+    crate::HOST_HYPERVISOR_CSR,
+};
 use crate::mmio::{ns16550, virtio, virtio::VIRTIO_MMIO_DEFAULT_ADDRESS};
 use crate::paging;
 use crate::plic;
@@ -400,7 +403,13 @@ fn instruction_abort_handler(scause: usize, registers: &mut [u64]) {
 
                 println!("CSRRS: {:#x}", csr_address)
             } else if instruction.is_sret() {
-                println!("sret");
+                let mut hypervisor_csr = HypervisorCsr::new();
+                hypervisor_csr.hstatus = get_hstatus();
+                hypervisor_csr.hgatp = get_hgatp();
+                let mut locked_csr = HOST_HYPERVISOR_CSR.lock();
+                *locked_csr = hypervisor_csr;
+
+                println!("{:?}", *locked_csr);
                 panic!();
             } else {
                 println!("[info] VIRTUAL INSTRUCTION: {:#x}", get_stval());

--- a/hypervisor/src/vector.rs
+++ b/hypervisor/src/vector.rs
@@ -34,12 +34,6 @@ machine_vector_table:
 supervisor_vector_table:
     j supervisor_exception_handler 
     
-.section .text
-.global virtual_supervisor_vector_table
-.balign 256
-virtual_supervisor_vector_table:
-    j virtual_supervisor_exception_handler 
-
 .text
 .global machine_exception_handler 
 .balign 256
@@ -199,82 +193,6 @@ supervisor_exception_handler:
     ld x31, 31*8(sp)
     addi sp, sp, 8*31
     sret
-
-.text
-.global virtual_supervisor_exception_handler 
-.balign 256
-virtual_supervisor_exception_handler:
-    addi sp, sp, -8*31
-    sd x0, 0*8(sp)
-    sd x1, 1*8(sp)
-    sd x2, 2*8(sp)
-    sd x3, 3*8(sp)
-    sd x4, 4*8(sp)
-    sd x5, 5*8(sp)
-    sd x6, 6*8(sp)
-    sd x7, 7*8(sp)
-    sd x8, 8*8(sp)
-    sd x9, 9*8(sp)
-    sd x10, 10*8(sp)
-    sd x11, 11*8(sp)
-    sd x12, 12*8(sp)
-    sd x13, 13*8(sp)
-    sd x14, 14*8(sp)
-    sd x15, 15*8(sp)
-    sd x16, 16*8(sp)
-    sd x17, 17*8(sp)
-    sd x18, 18*8(sp)
-    sd x19, 19*8(sp)
-    sd x20, 20*8(sp)
-    sd x21, 21*8(sp)
-    sd x22, 22*8(sp)
-    sd x23, 23*8(sp)
-    sd x24, 24*8(sp)
-    sd x25, 25*8(sp)
-    sd x26, 26*8(sp)
-    sd x27, 27*8(sp)
-    sd x28, 28*8(sp)
-    sd x29, 29*8(sp)
-    sd x30, 30*8(sp)
-    sd x31, 31*8(sp)
-    csrw sscratch, sp
-    la sp, _intr_stack_end
-    call exception_handler
-    csrr sp, sscratch
-    ld x0, 0*8(sp)
-    ld x1, 1*8(sp)
-    ld x2, 2*8(sp)
-    ld x3, 3*8(sp)
-    ld x4, 4*8(sp)
-    ld x5, 5*8(sp)
-    ld x6, 6*8(sp)
-    ld x7, 7*8(sp)
-    ld x8, 8*8(sp)
-    ld x9, 9*8(sp)
-    ld x10, 10*8(sp)
-    ld x11, 11*8(sp)
-    ld x12, 12*8(sp)
-    ld x13, 13*8(sp)
-    ld x14, 14*8(sp)
-    ld x15, 15*8(sp)
-    ld x16, 16*8(sp)
-    ld x17, 17*8(sp)
-    ld x18, 18*8(sp)
-    ld x19, 19*8(sp)
-    ld x20, 20*8(sp)
-    ld x21, 21*8(sp)
-    ld x22, 22*8(sp)
-    ld x23, 23*8(sp)
-    ld x24, 24*8(sp)
-    ld x25, 25*8(sp)
-    ld x26, 26*8(sp)
-    ld x27, 27*8(sp)
-    ld x28, 28*8(sp)
-    ld x29, 29*8(sp)
-    ld x30, 30*8(sp)
-    ld x31, 31*8(sp)
-    addi sp, sp, 8*31
-    sret
 "
 );
 
@@ -282,11 +200,9 @@ pub fn setup_vector() {
     unsafe extern "C" {
         static machine_vector_table: *const u8;
         static supervisor_vector_table: *const u8;
-        static virtual_supervisor_vector_table: *const u8;
     }
     unsafe { set_mtvec((&machine_vector_table as *const _ as usize) as u64) }
     unsafe { set_stvec((&supervisor_vector_table as *const _ as usize) as u64) }
-    unsafe { set_vstvec((&virtual_supervisor_vector_table as *const _ as usize) as u64) }
 }
 
 fn is_data_abort(scause: usize) -> bool {

--- a/hypervisor/src/vector.rs
+++ b/hypervisor/src/vector.rs
@@ -1,9 +1,4 @@
 use crate::PASS_THROUGH_VIRTIO_MMIO;
-#[cfg(feature = "nested_support")]
-use {
-    crate::emulate_csr::{HypervisorCsr, VIRTUAL_CSR, emulate_csr},
-    crate::HOST_HYPERVISOR_CSR,
-};
 use crate::mmio::{ns16550, virtio, virtio::VIRTIO_MMIO_DEFAULT_ADDRESS};
 use crate::paging;
 use crate::plic;
@@ -12,6 +7,11 @@ use crate::sbi;
 use arch::riscv::cpu::csr_address::CSR_TIME_ADDRESS;
 use arch::riscv::{cpu::*, instruction, instruction::Instruction};
 use core::arch::global_asm;
+#[cfg(feature = "nested_support")]
+use {
+    crate::HOST_HYPERVISOR_CSR,
+    crate::emulate_csr::{HypervisorCsr, VIRTUAL_CSR, emulate_csr},
+};
 
 pub const E_ILLEGAL_INSTRUCTION: usize = 2;
 pub const E_INSTRUCTION_GUEST_PAGE_FAULT: usize = 20;
@@ -373,8 +373,6 @@ fn instruction_abort_handler(scause: usize, registers: &mut [u64]) {
                     let write_value = registers[rs1];
                     emulate_csr(csr_address, rd, write_value, registers);
 
-                    println!("CSR: {:#x}", csr_address);
-
                     return;
                 }
 
@@ -387,7 +385,10 @@ fn instruction_abort_handler(scause: usize, registers: &mut [u64]) {
                     let rd = instruction.get_rd();
                     let rs1 = instruction.get_rs1();
                     let reg_value = registers[rs1];
-                    let csr_value = VIRTUAL_CSR.lock().get_csr(csr_address);
+                    let csr_value = {
+                        let locked_csr = VIRTUAL_CSR.lock();
+                        locked_csr.get_csr(csr_address)
+                    };
                     let write_value = csr_value | reg_value;
                     emulate_csr(csr_address, rd, write_value, registers);
 
@@ -401,7 +402,8 @@ fn instruction_abort_handler(scause: usize, registers: &mut [u64]) {
                     return;
                 }
 
-                println!("CSRRS: {:#x}", csr_address)
+                println!("CSRRS: {:#x}", csr_address);
+                panic!();
             } else if instruction.is_sret() {
                 let mut hypervisor_csr = HypervisorCsr::new();
                 hypervisor_csr.hstatus = get_hstatus();
@@ -409,6 +411,7 @@ fn instruction_abort_handler(scause: usize, registers: &mut [u64]) {
                 let mut locked_csr = HOST_HYPERVISOR_CSR.lock();
                 *locked_csr = hypervisor_csr;
 
+                // Implement this later
                 println!("{:?}", *locked_csr);
                 panic!();
             } else {

--- a/hypervisor/src/vector.rs
+++ b/hypervisor/src/vector.rs
@@ -4,7 +4,9 @@ use crate::paging;
 use crate::plic;
 use crate::println;
 use crate::sbi;
-use crate::emulate_csr::emulate_csr;
+#[cfg(feature = "nested_support")]
+use crate::emulate_csr::{emulate_csr, VIRTUAL_CSR};
+use arch::riscv::cpu::csr_address::CSR_TIME_ADDRESS;
 use arch::riscv::{cpu::*, instruction, instruction::Instruction};
 use core::arch::global_asm;
 
@@ -442,16 +444,41 @@ fn instruction_abort_handler(scause: usize, registers: &mut [u64]) {
         }
         E_VIRTUAL_INSTRUCTION => {
             let mut instruction = instruction::Instruction::new(get_stval() as u32);
-            if instruction.is_csrrs_instruction() {
-                let csr = instruction.get_funct12();
-                emulate_csr(csr, instruction, registers);
-                if csr == CSR_TIME_ADDRESS {
-                    let register_number = instruction.get_rd();
-                    registers[register_number] = get_time();
-                } else {
-                    println!("This csr number isn't supported: {:#x}", csr);
-                    panic!();
+
+            if instruction.is_csrrw_instruction() {
+                let csr_address = instruction.get_funct12();
+                #[cfg(feature = "nested_support")]
+                if csr_address::is_hypervisor_csr(csr_address) {
+                    let rd = instruction.get_rd();
+                    let rs1 = instruction.get_rs1();
+                    let write_value = registers[rs1];
+                    emulate_csr(csr_address, rd, write_value, registers);
+                    
+                    return;
                 }
+
+                println!("CSRRW: {:#x}", csr_address);
+            } else if instruction.is_csrrs_instruction() {
+                let csr_address = instruction.get_funct12();
+                #[cfg(feature = "nested_support")]
+                if csr_address::is_hypervisor_csr(csr_address) {
+                    let rd = instruction.get_rd();
+                    let rs1 = instruction.get_rs1();
+                    let reg_value = registers[rs1];
+                    let csr_value = VIRTUAL_CSR.lock().get_csr(csr_address);
+                    let write_value = csr_value | reg_value;
+                    emulate_csr(csr_address, rd, write_value, registers);
+                    
+                    return;
+                }
+                if csr_address == CSR_TIME_ADDRESS { // Read Only
+                    let rd = instruction.get_rd();
+                    registers[rd] = get_time();
+
+                    return;
+                } 
+
+                println!("CSRRS: {:#x}", csr_address)
             } else {
                 println!("[info] VIRTUAL INSTRUCTION: {:#x}", get_stval());
                 println!("[info] virtual address: {:#x}", get_sepc());

--- a/hypervisor/src/vector.rs
+++ b/hypervisor/src/vector.rs
@@ -328,7 +328,7 @@ fn read_access(virtual_address: usize, dst_register_idx: usize, registers: &mut 
 }
 
 fn data_abort_handler(scause: usize, registers: &mut [u64]) {
-    let mut instruction = instruction::Instruction::new(get_htinst() as u32);
+    let instruction = instruction::Instruction::new(get_htinst() as u32);
     match scause {
         E_STORE_AMO_GUEST_PAGE_FAULT => {
             // write access
@@ -359,7 +359,7 @@ fn instruction_abort_handler(scause: usize, registers: &mut [u64]) {
             panic!();
         }
         E_VIRTUAL_INSTRUCTION => {
-            let mut instruction = instruction::Instruction::new(get_stval() as u32);
+            let instruction = instruction::Instruction::new(get_stval() as u32);
 
             if instruction.is_csrrw_instruction() {
                 let csr_address = instruction.get_funct12();

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -45,7 +45,7 @@ impl VM {
 
 pub fn create_vm(bootloader: VirtioMmio, device_tree: VirtioMmio) -> VM {
     const RAM_VIRTUAL_BASE: usize = 0x80000000;
-    const RAM_SIZE: usize = 0x10000000;
+    const RAM_SIZE: usize = 0x20000000;
 
     let ram_physical_base_address = allocate_pages(RAM_SIZE / paging::PAGE_SIZE, paging::PAGE_SIZE);
     if ram_physical_base_address.is_null() {

--- a/l1_hypervisor.ld
+++ b/l1_hypervisor.ld
@@ -1,0 +1,40 @@
+OUTPUT_ARCH(riscv)
+ENTRY(main)
+
+SECTIONS
+{
+  . = 0x80200000; 
+  
+  .text : {
+    *(.text)
+    *(.text.*)
+  }
+  
+  .rodata : {
+    *(.strings)
+    *(.rodata)
+    *(.rodata.*)
+  }
+
+  .data : {
+    *(.data)
+    *(.data.*)
+  }
+
+  .bss : {
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+  }
+
+  . = ALIGN(4096);
+
+  .intr_stack (NOLOAD) : {
+    _intr_stack_start = .;
+    . = . + 0x2000;
+    _intr_stack_end = .;
+  }
+
+  _free_area = . ;
+
+}

--- a/l1_hypervisor/.cargo/config.toml
+++ b/l1_hypervisor/.cargo/config.toml
@@ -1,6 +1,6 @@
 [build]
 target = "riscv64gc-unknown-none-elf"
-rustflags = ["-C", "link-arg=-Thypervisor.ld"]
+rustflags = ["-C", "link-arg=-Tl1_hypervisor.ld"]
 
 [unstable]
 build-std = ["core", "alloc", "compiler_builtins"]

--- a/l1_hypervisor/Cargo.toml
+++ b/l1_hypervisor/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2024"
 allocator.workspace = true
 arch = { version = "0.1.0", path = "../arch" }
 fdt.workspace = true
-log = { version = "0.4.28", features = ["max_level_debug"]}
 spin = "0.10.0"
 string_utils.workspace = true

--- a/l1_hypervisor/src/main.rs
+++ b/l1_hypervisor/src/main.rs
@@ -124,38 +124,23 @@ extern "C" fn main(argc: usize, argv: *const *const u8) {
         ram_physical_base_address as usize
     );
 
-    let stack_memory = allocate_pages(2, paging::PAGE_SIZE);
+    let stack_size = 0x2000;
+    let stack_memory = allocate_pages(stack_size / paging::PAGE_SIZE, paging::PAGE_SIZE);
     if stack_memory.is_null() {
         println!("Failed to allocate memory for VM stack.");
         panic!();
     }
+    let stack_pointer = stack_memory as usize + stack_size;
 
     let virtual_entry_point = 0x80200000;
-    const VM_MAIN: usize = 0x0;
-    let physical_entry_point = VM_MAIN;
+    let physical_entry_point = 0x0;
     println!(
         "[info] vm entry point physical address: {:#X}",
         physical_entry_point
     );
 
-    match paging::add_mapping_stage2(
-        physical_entry_point,
-        virtual_entry_point,
-        paging::PAGE_SIZE * 10,
-        table_address,
-        paging::DEFAULT_TABLE_LEVEL,
-        true,
-        true,
-        true,
-    ) {
-        Ok(_) => {}
-        Err(_) => {
-            panic!();
-        }
-    }
-
     println!("switch to guest");
-    hs_to_vs(virtual_entry_point, stack_memory as usize, 0x0)
+    hs_to_vs(virtual_entry_point, stack_pointer, 0x0)
 }
 
 pub fn halt_loop() -> ! {

--- a/l1_hypervisor/src/main.rs
+++ b/l1_hypervisor/src/main.rs
@@ -124,20 +124,72 @@ extern "C" fn main(argc: usize, argv: *const *const u8) {
         ram_physical_base_address as usize
     );
 
+    let stack_memory = allocate_pages(2, paging::PAGE_SIZE);
+    if stack_memory.is_null() {
+        println!("Failed to allocate memory for VM stack.");
+        panic!();
+    }
+
     let virtual_entry_point = 0x80200000;
-    let bootloader_entry_point = paging::resolve_address_stage2(virtual_entry_point).unwrap();
+    let physical_entry_point = virtual_machine_main as usize;
     println!(
         "[info] vm entry point physical address: {:#X}",
-        bootloader_entry_point
+       physical_entry_point 
     );
 
-    halt_loop();
+    match paging::add_mapping_stage2(
+        physical_entry_point,
+        virtual_entry_point,
+        paging::PAGE_SIZE * 10,
+        table_address,
+        paging::DEFAULT_TABLE_LEVEL,
+        true,
+        true,
+        true,
+    ) {
+        Ok(_) => {},
+        Err(_) => {
+            panic!();
+        }
+    }
+
+    
+    println!("switch to guest");
+    hs_to_vs(
+        virtual_entry_point,
+        stack_memory as usize,
+        0x0,
+    )
 }
 
 pub fn halt_loop() -> ! {
     loop {
         unsafe { asm!("wfi") };
     }
+}
+
+fn hs_to_vs(vs_entry_point: usize, vs_stack_pointer: usize, dtb_pointer: usize) -> ! {
+    unsafe {
+        asm!("
+            csrs sstatus, {tmp1}
+            csrs hstatus, {tmp2}
+            csrw sepc, {entry_point}
+            mv sp, {stack_pointer}
+            mv a1, {dtb_pointer}
+            sret", 
+        tmp1 = in(reg) 0x100, // set sstatus.SPP
+        tmp2 = in(reg) 0x80, // set hstatus.SPV
+        stack_pointer = in(reg) vs_stack_pointer,
+        entry_point = in(reg) vs_entry_point,
+        dtb_pointer = in(reg) dtb_pointer,
+        options(noreturn)
+        )
+    };
+}
+
+fn virtual_machine_main() -> ! {
+    println!("Hello from Virtual Machine!");
+    halt_loop();
 }
 
 #[panic_handler]

--- a/l1_hypervisor/src/main.rs
+++ b/l1_hypervisor/src/main.rs
@@ -91,9 +91,13 @@ extern "C" fn main(argc: usize, argv: *const *const u8) {
     println!("[info] sstatus: {:#x}", sstatus as usize);
 
     const RAM_VIRTUAL_BASE: usize = 0x80000000;
-    const RAM_SIZE: usize = 0x10000000;
+    const RAM_SIZE: usize = 0x8000000;
 
     let ram_physical_base_address = allocate_pages(RAM_SIZE / paging::PAGE_SIZE, paging::PAGE_SIZE);
+    if ram_physical_base_address.is_null() {
+        println!("out of memory.");
+        panic!();
+    }
     let table_address = paging::map_address_stage2(
         ram_physical_base_address as usize,
         RAM_VIRTUAL_BASE,

--- a/l1_hypervisor/src/main.rs
+++ b/l1_hypervisor/src/main.rs
@@ -131,7 +131,8 @@ extern "C" fn main(argc: usize, argv: *const *const u8) {
     }
 
     let virtual_entry_point = 0x80200000;
-    let physical_entry_point = virtual_machine_main as usize;
+    const VM_MAIN: usize = 0x0;
+    let physical_entry_point = VM_MAIN;
     println!(
         "[info] vm entry point physical address: {:#X}",
         physical_entry_point
@@ -180,11 +181,6 @@ fn hs_to_vs(vs_entry_point: usize, vs_stack_pointer: usize, dtb_pointer: usize) 
         options(noreturn)
         )
     };
-}
-
-fn virtual_machine_main() -> ! {
-    println!("Hello from Virtual Machine!");
-    halt_loop();
 }
 
 #[panic_handler]

--- a/l1_hypervisor/src/main.rs
+++ b/l1_hypervisor/src/main.rs
@@ -5,6 +5,7 @@ mod console;
 mod memory;
 mod paging;
 
+use arch::riscv::cpu::{get_hedeleg, set_hedeleg};
 use arch::riscv::sbi;
 use core::alloc::{GlobalAlloc, Layout};
 use core::arch::asm;
@@ -95,6 +96,11 @@ extern "C" fn main(argc: usize, argv: *const *const u8) {
         .lock()
         .init(free_ptr, memory.size - (free_ptr - memory.address));
     println!("[setup] allocator");
+
+    let mut hedeleg = get_hedeleg();
+    hedeleg |= (1 << 2) as u64; // Illegal instruction
+    set_hedeleg(hedeleg);
+    println!("[setup] hedeleg");
 
     halt_loop();
 }

--- a/l1_hypervisor/src/main.rs
+++ b/l1_hypervisor/src/main.rs
@@ -10,29 +10,10 @@ use arch::riscv::sbi;
 use core::alloc::{GlobalAlloc, Layout};
 use core::arch::asm;
 use fdt::{DeviceTreeInfo, MemoryEntry};
-use log;
 use spin::Mutex;
 use string_utils::hex_ptr_to_usize;
 
 use crate::memory::allocate_pages;
-
-pub struct SbiConsoleLogger;
-
-impl log::Log for SbiConsoleLogger {
-    fn enabled(&self, metadata: &log::Metadata) -> bool {
-        metadata.level() <= log::Level::Debug
-    }
-
-    fn log(&self, record: &log::Record) {
-        if self.enabled(record.metadata()) {
-            println!("{} - {}", record.level(), record.args());
-        }
-    }
-
-    fn flush(&self) {}
-}
-
-static LOGGER: SbiConsoleLogger = SbiConsoleLogger;
 
 struct GlobalAllocator {}
 
@@ -63,9 +44,6 @@ const MAX_MMIO_ENTRIES: usize = 64;
 
 #[unsafe(no_mangle)]
 extern "C" fn main(argc: usize, argv: *const *const u8) {
-    log::set_logger(&LOGGER).unwrap();
-    log::set_max_level(log::LevelFilter::Debug);
-
     if argc < 1 {
         panic!("fdt pointer isn't configured");
     }

--- a/l1_hypervisor/src/main.rs
+++ b/l1_hypervisor/src/main.rs
@@ -5,7 +5,7 @@ mod console;
 mod memory;
 mod paging;
 
-use arch::riscv::cpu::{get_hedeleg, set_hedeleg};
+use arch::riscv::cpu::*;
 use arch::riscv::sbi;
 use core::alloc::{GlobalAlloc, Layout};
 use core::arch::asm;
@@ -13,6 +13,8 @@ use fdt::{DeviceTreeInfo, MemoryEntry};
 use log;
 use spin::Mutex;
 use string_utils::hex_ptr_to_usize;
+
+use crate::memory::allocate_pages;
 
 pub struct SbiConsoleLogger;
 
@@ -101,6 +103,51 @@ extern "C" fn main(argc: usize, argv: *const *const u8) {
     hedeleg |= (1 << 2) as u64; // Illegal instruction
     set_hedeleg(hedeleg);
     println!("[setup] hedeleg");
+
+    let mut hie = get_hie();
+    hie |= XIE_SEIE as u64;
+    set_hie(hie);
+    println!("[setup] hie");
+
+    let sstatus = get_sstatus();
+    println!("[info] sstatus: {:#x}", sstatus as usize);
+
+    const RAM_VIRTUAL_BASE: usize = 0x80000000;
+    const RAM_SIZE: usize = 0x10000000;
+
+    let ram_physical_base_address = allocate_pages(RAM_SIZE / paging::PAGE_SIZE, paging::PAGE_SIZE);
+    let table_address = paging::map_address_stage2(
+        ram_physical_base_address as usize,
+        RAM_VIRTUAL_BASE,
+        RAM_SIZE,
+        paging::DEFAULT_TABLE_LEVEL,
+        true,
+        true,
+        true,
+    )
+    .expect("Failed to mapping");
+    println!("[info] table_address");
+    let mut hgatp = match paging::DEFAULT_TABLE_LEVEL {
+        3 => 0b1000 << 60,
+        4 => 0b1001 << 60,
+        5 => 0b1010 << 60,
+        _ => unreachable!(),
+    };
+    hgatp |= (table_address >> 12) & SATP_PPN_MASK;
+    set_hgatp(hgatp as u64);
+
+    println!("[info] vm virtual address: {:#X}", RAM_VIRTUAL_BASE);
+    println!(
+        "[info] vm physical address: {:#X}",
+        ram_physical_base_address as usize
+    );
+
+    let virtual_entry_point = 0x80200000;
+    let bootloader_entry_point = paging::resolve_address_stage2(virtual_entry_point).unwrap();
+    println!(
+        "[info] vm entry point physical address: {:#X}",
+        bootloader_entry_point
+    );
 
     halt_loop();
 }

--- a/l1_hypervisor/src/main.rs
+++ b/l1_hypervisor/src/main.rs
@@ -134,7 +134,7 @@ extern "C" fn main(argc: usize, argv: *const *const u8) {
     let physical_entry_point = virtual_machine_main as usize;
     println!(
         "[info] vm entry point physical address: {:#X}",
-       physical_entry_point 
+        physical_entry_point
     );
 
     match paging::add_mapping_stage2(
@@ -147,19 +147,14 @@ extern "C" fn main(argc: usize, argv: *const *const u8) {
         true,
         true,
     ) {
-        Ok(_) => {},
+        Ok(_) => {}
         Err(_) => {
             panic!();
         }
     }
 
-    
     println!("switch to guest");
-    hs_to_vs(
-        virtual_entry_point,
-        stack_memory as usize,
-        0x0,
-    )
+    hs_to_vs(virtual_entry_point, stack_memory as usize, 0x0)
 }
 
 pub fn halt_loop() -> ! {

--- a/l1_hypervisor/src/memory.rs
+++ b/l1_hypervisor/src/memory.rs
@@ -16,6 +16,16 @@ pub fn allocate_pages(num_of_pages: usize, align: usize) -> *mut u8 {
     }
 }
 
+pub fn callocate_pages(num_of_pages: usize, align: usize) -> *mut u8 {
+    let layout =
+        unsafe { Layout::from_size_align_unchecked(num_of_pages * paging::PAGE_SIZE, align) };
+
+    match MEMORY_ALLOCATOR.lock().callocate(layout) {
+        Ok(ptr) => ptr.as_ptr(),
+        Err(_) => core::ptr::null_mut(),
+    }
+}
+
 #[allow(dead_code)]
 pub fn set_pmp(
     top_address: usize,

--- a/l1_hypervisor/src/paging.rs
+++ b/l1_hypervisor/src/paging.rs
@@ -205,6 +205,7 @@ pub fn map_address_stage2(
         return Err(());
     }
     let table_address = table_address_ptr as usize;
+    println!("table_address_ptr: {:#x}", table_address_ptr as usize);
 
     let top_level_stage_2_num_of_entries = 1 << G_STAGE_TOP_VPN_SIZE;
 

--- a/l1_hypervisor/src/paging.rs
+++ b/l1_hypervisor/src/paging.rs
@@ -205,7 +205,6 @@ pub fn map_address_stage2(
         return Err(());
     }
     let table_address = table_address_ptr as usize;
-    println!("table_address_ptr: {:#x}", table_address_ptr as usize);
 
     let top_level_stage_2_num_of_entries = 1 << G_STAGE_TOP_VPN_SIZE;
 

--- a/l1_hypervisor/src/paging.rs
+++ b/l1_hypervisor/src/paging.rs
@@ -2,7 +2,7 @@
 
 use core::borrow::BorrowMut;
 
-use crate::memory::allocate_pages;
+use crate::memory::callocate_pages;
 use crate::println;
 use arch::riscv::cpu::*;
 
@@ -159,7 +159,7 @@ fn _map_address_stage2(
         e.init();
         let mut next_table_address = e.get_next_table_address();
         if !e.is_valid_pte() {
-            let new_table_address = allocate_pages(1, PAGE_SIZE);
+            let new_table_address = callocate_pages(1, PAGE_SIZE);
             if new_table_address.is_null() {
                 println!("Failed to allocate pages for stage2 page table.");
                 return Err(());
@@ -199,7 +199,7 @@ pub fn map_address_stage2(
         println!("Map size is not aligned.");
         return Err(());
     }
-    let table_address_ptr = allocate_pages(4, 1 << 14);
+    let table_address_ptr = callocate_pages(4, 1 << 14);
     if table_address_ptr.is_null() {
         println!("Failed to allocate pages for stage 2 page table.");
         return Err(());

--- a/l1_hypervisor/src/paging.rs
+++ b/l1_hypervisor/src/paging.rs
@@ -239,3 +239,46 @@ pub fn map_address_stage2(
 
     Ok(table_address as usize)
 }
+
+pub fn add_mapping_stage2(
+    mut physical_address: usize,
+    mut virtual_address: usize,
+    mut map_size: usize,
+    table_address: usize,
+    table_level: i8,
+    is_readable: bool,
+    is_writable: bool,
+    is_executable: bool,
+) -> Result<(), ()> {
+    let top_level_stage_2_num_of_entries = 1 << G_STAGE_TOP_VPN_SIZE;
+
+    let mut permission: u64 = if is_readable {
+        (1 << TableEntry::R_OFFSET) as u64
+    } else {
+        0
+    };
+
+    permission |= if is_writable {
+        (1 << TableEntry::W_OFFSET) as u64
+    } else {
+        0
+    };
+
+    permission |= if is_executable {
+        (1 << TableEntry::X_OFFSET) as u64
+    } else {
+        0
+    };
+
+    _map_address_stage2(
+        &mut physical_address,
+        &mut virtual_address,
+        &mut map_size,
+        table_address,
+        permission,
+        table_level - 1,
+        top_level_stage_2_num_of_entries,
+    )?;
+
+    Ok(())
+}

--- a/scripts/virt.dts
+++ b/scripts/virt.dts
@@ -8,7 +8,7 @@
 
   memory@80000000 {
     device_type = "memory";
-    reg = <0x0 0x80000000 0x0 0x10000000>;
+    reg = <0x0 0x80000000 0x0 0x20000000>;
   };
 
   cpus {

--- a/support/allocator/Cargo.toml
+++ b/support/allocator/Cargo.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-log = "0.4.28"

--- a/support/allocator/src/lib.rs
+++ b/support/allocator/src/lib.rs
@@ -89,6 +89,18 @@ impl<const ORDER: usize> Heap<ORDER> {
         Err(())
     }
 
+    pub fn callocate(&mut self, layout: Layout) -> Result<NonNull<u8>, ()> {
+        let size = max(
+            layout.size().next_power_of_two(),
+            max(layout.align(), size_of::<usize>()),
+        );
+        let memory = self.allocate(layout)?;
+        unsafe {
+            core::ptr::write_bytes(memory.as_ptr(), 0, size);
+        }
+        Ok(memory)
+    }
+
     pub fn deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) {
         let size = max(
             layout.size().next_power_of_two(),

--- a/support/fdt/Cargo.toml
+++ b/support/fdt/Cargo.toml
@@ -6,4 +6,3 @@ edition = "2024"
 [dependencies]
 byteorder = { version = "1", default-features = false }
 arrayvec = { version = "0.7.6", default-features = false }
-log = { version = "0.4.28", features = ["max_level_debug"]}

--- a/support/fdt/src/lib.rs
+++ b/support/fdt/src/lib.rs
@@ -265,7 +265,6 @@ impl<const MAX_MEMORY_ENTRIES: usize, const MAX_MMIO_ENTRIES: usize>
                 return Err(FdtError::UnexpectedEOF);
             }
             let token = Self::read_be32(fdt.get_struct_block_address(*offset));
-            // log::debug!("offset: {:#x}, token: {}", fdt.get_struct_block_address(*offset) as usize, token);
             *offset += 1;
             match token {
                 FDT_BEGIN_NODE => Self::skip_fdt_node(fdt, offset)?,
@@ -283,12 +282,10 @@ impl<const MAX_MEMORY_ENTRIES: usize, const MAX_MMIO_ENTRIES: usize>
         let mut props: FdtNodeProps<MAX_NODE_PROPS> = FdtNodeProps {
             props: ArrayVec::new(),
         };
-        // log::debug!("scan node properties");
         while Self::fdt_prop_iteration(fdt, offset)? {
             let current_address = fdt.get_struct_block_address(*offset);
             let prop_data = Self::get_prop_data(current_address);
             let prop = Self::get_prop(fdt, offset, &prop_data)?;
-            // log::debug!("{:#x}: {}", current_address as usize, prop.name);
 
             props.props.try_push(prop)?;
         }
@@ -299,7 +296,6 @@ impl<const MAX_MEMORY_ENTRIES: usize, const MAX_MMIO_ENTRIES: usize>
     fn skip_fdt_node(fdt: &FdtContext, offset: &mut usize) -> Result<(), FdtError> {
         let mut token = Self::read_be32(fdt.get_struct_block_address(*offset));
         while token != FDT_END_NODE {
-            // log::debug!("skip: {:#x}:{:#x}", fdt.get_struct_block_address(*offset) as usize, token as usize);
             match token {
                 FDT_PROP => {
                     *offset += 1;
@@ -311,11 +307,9 @@ impl<const MAX_MEMORY_ENTRIES: usize, const MAX_MMIO_ENTRIES: usize>
                     if !(prop_data.len as usize).is_multiple_of(size_of::<u32>()) {
                         *offset += 1;
                     }
-                    // log::debug!("skip: prop {:#x}", fdt.get_struct_block_address(*offset) as usize);
                 }
                 FDT_BEGIN_NODE => {
                     *offset += 1;
-                    // log::debug!("nest");
                     Self::skip_fdt_node(fdt, offset)?;
                 }
                 _ => {}
@@ -329,7 +323,6 @@ impl<const MAX_MEMORY_ENTRIES: usize, const MAX_MMIO_ENTRIES: usize>
     }
 
     pub fn parse(&mut self, fdt_address: *const u32) -> Result<(), FdtError> {
-        // log::debug!("parse fdt binary");
         let header = self.parse_header(fdt_address);
         let mut fdt_context = FdtContext {
             fdt_address,
@@ -341,7 +334,6 @@ impl<const MAX_MEMORY_ENTRIES: usize, const MAX_MMIO_ENTRIES: usize>
         const MAX_NODE_PROPS: usize = 32;
 
         while Self::fdt_node_iteration(&mut fdt_context)? {
-            // log::debug!("iteration");
             let mut prop_offset = fdt_context.struct_current_offset;
             let props =
                 Self::scan_node_properties::<MAX_NODE_PROPS>(&fdt_context, &mut prop_offset)?;

--- a/u-boot/build.sh
+++ b/u-boot/build.sh
@@ -1,3 +1,5 @@
+mkdir -p ../bin/disk
+
 cd u-boot
 make qemu-riscv64_defconfig
 CROSS_COMPILE=riscv64-linux-gnu- make -j$(nproc)


### PR DESCRIPTION
# Summary
- Virtualize Hypervisor CSR access from L1 Hypervisor
- Make shadow page table which converts guest virtual address to physical address

## Related Issue / Task

## What's Changed
- Double intr stack size
- Define HypervisorCsr struct
- Shadow page table
  - Add load/store function from Virtual Machine(arch/src/riscv/instruction.rs)
- Hooked accessing hypervisor csr from L1 hypervisor
- Remove trap handler from VS-mode
- Add linker script for L1 hypervisor

## Testing and Review

### **Steps to Test**

### **Test Configuration (if applicable)**

## Reviewer Checklist

## Additional Notes / Concerns