### PR TITLE
[feat] display virtial indicators in serial

### DIFF
--- a/hypervisor/src/sbi.rs
+++ b/hypervisor/src/sbi.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use crate::mmio::ns16550::putc;
+use crate::print;
 use crate::println;
 
 pub const SBI_EXT_BASE: usize = 0x10;
@@ -42,7 +43,12 @@ pub fn virtual_sbi(
         },
         SBI_EXT_0_1_CONSOLE_PUTCHAR => {
             if fid == 0 {
-                putc(_arg0 as u8);
+                if let Some(ch) = char::from_u32(_arg0 as u32) {
+                    putc(_arg0 as u8);
+                    if ch == '\n' {
+                        print!("[L1 VM] ");
+                    }
+                }
                 Sbiret { error: 0, value: 0 }
             } else {
                 println!("fid: {}", fid);

--- a/hypervisor/src/sbi.rs
+++ b/hypervisor/src/sbi.rs
@@ -43,8 +43,8 @@ pub fn virtual_sbi(
         },
         SBI_EXT_0_1_CONSOLE_PUTCHAR => {
             if fid == 0 {
+                putc(_arg0 as u8);
                 if let Some(ch) = char::from_u32(_arg0 as u32) {
-                    putc(_arg0 as u8);
                     if ch == '\n' {
                         print!("[L1 VM] ");
                     }

--- a/hypervisor/src/virtual_devices/serial/ns16550.rs
+++ b/hypervisor/src/virtual_devices/serial/ns16550.rs
@@ -10,16 +10,16 @@ impl MmioHandler for Ns16550 {
     }
 
     fn write(&mut self, offset: usize, value: usize) {
+        ns16550_set_by_offset(offset, value as u8);
         match offset {
             0x0 => {
                 if let Some(ch) = char::from_u32(value as u32) {
-                    ns16550_set_by_offset(offset, value as u8);
                     if ch == '\n' {
                         print!("[L1 VM] ");
                     }
                 }
             }
-            _ => ns16550_set_by_offset(offset, value as u8),
+            _ => {}
         }
     }
 }

--- a/hypervisor/src/virtual_devices/serial/ns16550.rs
+++ b/hypervisor/src/virtual_devices/serial/ns16550.rs
@@ -1,3 +1,4 @@
+use crate::print;
 use mmio_core::MmioHandler;
 
 #[derive(Debug)]
@@ -9,7 +10,17 @@ impl MmioHandler for Ns16550 {
     }
 
     fn write(&mut self, offset: usize, value: usize) {
-        ns16550_set_by_offset(offset, value as u8);
+        match offset {
+            0x0 => {
+                if let Some(ch) = char::from_u32(value as u32) {
+                    ns16550_set_by_offset(offset, value as u8);
+                    if ch == '\n' {
+                        print!("[L1 VM] ");
+                    }
+                }
+            }
+            _ => ns16550_set_by_offset(offset, value as u8),
+        }
     }
 }
 

--- a/l1_hypervisor/src/virtual_devices/serial/ns16550.rs
+++ b/l1_hypervisor/src/virtual_devices/serial/ns16550.rs
@@ -10,16 +10,16 @@ impl MmioHandler for Ns16550 {
     }
 
     fn write(&mut self, offset: usize, value: usize) {
+        ns16550_set_by_offset(offset, value as u8);
         match offset {
             0x0 => {
                 if let Some(ch) = char::from_u32(value as u32) {
-                    ns16550_set_by_offset(offset, value as u8);
                     if ch == '\n' {
                         print!("[L2 VM] ");
                     }
                 }
             }
-            _ => ns16550_set_by_offset(offset, value as u8),
+            _ => {}
         }
     }
 }

--- a/l1_hypervisor/src/virtual_devices/serial/ns16550.rs
+++ b/l1_hypervisor/src/virtual_devices/serial/ns16550.rs
@@ -1,3 +1,4 @@
+use crate::print;
 use mmio_core::MmioHandler;
 
 #[derive(Debug)]
@@ -9,7 +10,17 @@ impl MmioHandler for Ns16550 {
     }
 
     fn write(&mut self, offset: usize, value: usize) {
-        ns16550_set_by_offset(offset, value as u8);
+        match offset {
+            0x0 => {
+                if let Some(ch) = char::from_u32(value as u32) {
+                    ns16550_set_by_offset(offset, value as u8);
+                    if ch == '\n' {
+                        print!("[L2 VM] ");
+                    }
+                }
+            }
+            _ => ns16550_set_by_offset(offset, value as u8),
+        }
     }
 }
 


### PR DESCRIPTION
# Summary
- Display `[L1 VM]` when L1 VM uses virtual uart
- Display `[L2 VM]` when L2 VM uses virtual uart or virtual sbi 

## Related Issue / Task

## What's Changed

## Testing and Review

### **Steps to Test**

### **Test Configuration (if applicable)**

## Reviewer Checklist

## Additional Notes / Concerns
