### PR TITLE
feat: Implement nested acceleration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "support/allocate_pages",
   "support/fat32",
   "support/virtio_core",
+  "support/shmem",
   "xtask",
 ]
 

--- a/arch/src/riscv/cpu.rs
+++ b/arch/src/riscv/cpu.rs
@@ -58,6 +58,10 @@ pub const PMP_A_FIELD_NAPOT: usize = 3;
 
 pub const ENVCFG_ADUE_OFFSET: usize = 61;
 
+// Sstc
+
+pub const MENVCFG_STCE: usize = 1 << 63;
+
 // CSRs address
 pub mod csr_address {
     // Machine
@@ -733,6 +737,11 @@ pub fn get_time() -> u64 {
     let time: u64;
     unsafe { asm!("csrr {}, time", out(reg) time ) };
     time
+}
+
+#[inline(always)]
+pub fn set_stimecmp(stimecmp: u64) {
+    unsafe { asm!("csrw stimecmp, {}", in(reg) stimecmp ) };
 }
 
 // aia

--- a/arch/src/riscv/instruction.rs
+++ b/arch/src/riscv/instruction.rs
@@ -64,7 +64,7 @@ impl Instruction {
         ((self.0 & Self::FUNCT12_MASK) >> Self::FUNCT12_OFFSET) as usize
     }
 
-    pub fn get_compression(&mut self) -> usize {
+    pub fn get_compression(&self) -> usize {
         ((self.0 & Self::COMPRESSION_MASK) >> Self::COMPRESSION_OFFSET) as usize
     }
 
@@ -96,7 +96,7 @@ impl Instruction {
             && self.get_funct7() == Self::FUNCT7_SRET
     }
 
-    pub fn is_compression_instruction(&mut self) -> bool {
+    pub fn is_compression_instruction(&self) -> bool {
         let compression = self.get_compression();
         compression == Self::COMPRESSED_INSTRUCTION
     }

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -22,3 +22,4 @@ shmem = { version = "0.1.0", path = "../support/shmem" }
 
 [features]
 nested_support = []
+nested_acceleration = ["nested_support"]

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -18,6 +18,7 @@ allocate_pages = { version = "0.1.0", path = "../support/allocate_pages" }
 fat32 = { version = "0.1.0", path = "../support/fat32" }
 virtio_core = { version = "0.1.0", path = "../support/virtio_core" }
 log = { version = "0.4.29", features = ["max_level_trace"] }
+shmem = { version = "0.1.0", path = "../support/shmem" }
 
 [features]
 nested_support = []

--- a/hypervisor/src/main.rs
+++ b/hypervisor/src/main.rs
@@ -78,6 +78,9 @@ macro_rules! bitmask {
 const MAX_MEMORY_ENTRIES: usize = 32;
 const MAX_MMIO_ENTRIES: usize = 64;
 
+const SHMEM_VIRTUAL_ADDRESS: usize = 0xb0000000;
+const SHMEM_SIZE: usize = 0x4000000;
+
 // fn intr_disable() {
 //     set_mie(get_mie() & !(1 << MIE_MEIE_OFFSET));
 // }

--- a/hypervisor/src/main.rs
+++ b/hypervisor/src/main.rs
@@ -10,9 +10,12 @@ mod console;
 #[cfg(feature = "nested_support")]
 mod emulate_csr;
 mod memory;
+#[cfg(feature = "nested_support")]
+mod nested;
 mod paging;
 mod plic;
 mod sbi;
+#[cfg(feature = "nested_acceleration")]
 mod timer;
 mod vector;
 mod vm;
@@ -24,6 +27,68 @@ mod virtual_devices {
 }
 mod mmio {
     pub mod ns16550;
+}
+
+#[cfg(feature = "nested_acceleration")]
+pub mod shmem_handle {
+    use super::SHM_RING;
+    use core::marker::PhantomData;
+    use shmem::ShmRing;
+
+    pub const SHMEM_VIRTUAL_ADDRESS: usize = 0xb0000000;
+    pub const SHMEM_SIZE: usize = 0x4000000;
+
+    #[derive(Clone, Copy)]
+    pub struct ShmRingHandle {
+        ptr: core::ptr::NonNull<ShmRing>,
+        _p: PhantomData<&'static ShmRing>,
+    }
+
+    unsafe impl Send for ShmRingHandle {}
+    unsafe impl Sync for ShmRingHandle {}
+
+    impl ShmRingHandle {
+        pub unsafe fn from_base(base: usize) -> Self {
+            assert!(
+                base % align_of::<ShmRing>() == 0,
+                "ShmRing alignment mismatch"
+            );
+            let ptr = core::ptr::NonNull::new(base as *mut ShmRing).expect("null shm base");
+            Self {
+                ptr,
+                _p: PhantomData,
+            }
+        }
+
+        #[inline]
+        pub fn ring(&self) -> &ShmRing {
+            unsafe { self.ptr.as_ref() }
+        }
+
+        #[inline]
+        pub fn ring_mut(&mut self) -> &mut ShmRing {
+            unsafe { self.ptr.as_mut() }
+        }
+    }
+
+    pub fn init_shm_ring(base: usize) {
+        SHM_RING.call_once(|| {
+            let h = unsafe { ShmRingHandle::from_base(base) };
+            spin::Mutex::new(h)
+        });
+    }
+
+    pub fn with_shm_ring<R>(f: impl FnOnce(&ShmRing) -> R) -> R {
+        let m = SHM_RING.get().expect("call init_shm_ring() first");
+        let h = *m.lock();
+        f(h.ring())
+    }
+
+    pub fn with_shm_ring_mut<R>(f: impl FnOnce(&mut ShmRing) -> R) -> R {
+        let m = SHM_RING.get().expect("call init_shm_ring() first");
+        let mut h = *m.lock();
+        f(h.ring_mut())
+    }
 }
 
 use crate::alloc::string::ToString;
@@ -38,15 +103,15 @@ use block::mem_blk::MemBlk;
 use block::virtio_blk::VirtioBlk;
 use core::alloc::{GlobalAlloc, Layout};
 use core::arch::asm;
-use core::marker::PhantomData;
 use core::ptr::NonNull;
 use fdt::DeviceTreeInfo;
 use lazy_static::lazy_static;
 use log::{Level, Metadata, Record};
 use memory::set_pmp_all_physical_address;
 use mmio::ns16550::Uart;
-use shmem::ShmRing;
-use spin::{Mutex, Once};
+use spin::Mutex;
+#[cfg(feature = "nested_acceleration")]
+use spin::Once;
 use string_utils::hex_ptr_to_usize;
 use vector::setup_vector;
 use virtio::{VIRTIO_MMIO_DEFAULT_ADDRESS, VirtioMmio};
@@ -81,76 +146,23 @@ macro_rules! bitmask {
 const MAX_MEMORY_ENTRIES: usize = 32;
 const MAX_MMIO_ENTRIES: usize = 64;
 
-const SHMEM_VIRTUAL_ADDRESS: usize = 0xb0000000;
-const SHMEM_SIZE: usize = 0x4000000;
-
 // fn intr_disable() {
 //     set_mie(get_mie() & !(1 << MIE_MEIE_OFFSET));
 // }
-
-#[derive(Clone, Copy)]
-pub struct ShmRingHandle {
-    ptr: NonNull<ShmRing>,
-    _p: PhantomData<&'static ShmRing>,
-}
-
-unsafe impl Send for ShmRingHandle {}
-unsafe impl Sync for ShmRingHandle {}
-
-impl ShmRingHandle {
-    pub unsafe fn from_base(base: usize) -> Self {
-        assert!(
-            base % align_of::<ShmRing>() == 0,
-            "ShmRing alignment mismatch"
-        );
-        let ptr = NonNull::new(base as *mut ShmRing).expect("null shm base");
-        Self {
-            ptr,
-            _p: PhantomData,
-        }
-    }
-
-    #[inline]
-    pub fn ring(&self) -> &ShmRing {
-        unsafe { self.ptr.as_ref() }
-    }
-
-    #[inline]
-    pub fn ring_mut(&mut self) -> &mut ShmRing {
-        unsafe { self.ptr.as_mut() }
-    }
-}
 
 static LOGGER: SimpleLogger = SimpleLogger;
 static MEMORY_ALLOCATOR: Mutex<allocator::Heap<33>> = Mutex::new(allocator::Heap::new());
 static VIRTUAL_UART_DEVICE: Mutex<Uart> = Mutex::new(Uart::new());
 static CURRENT_VMID: Mutex<usize> = Mutex::new(0);
-static SHM_RING: Once<Mutex<ShmRingHandle>> = Once::new();
+#[cfg(feature = "nested_acceleration")]
+static SHM_RING: Once<Mutex<shmem_handle::ShmRingHandle>> = Once::new();
+#[cfg(feature = "nested_acceleration")]
 static BUFFER_COUNT: Mutex<usize> = Mutex::new(0);
 #[cfg(feature = "nested_support")]
 static HOST_HYPERVISOR_CSR: Mutex<HypervisorCsr> = Mutex::new(HypervisorCsr::new());
 
 lazy_static! {
     pub static ref VIRTUAL_MACHINES: Mutex<Vec<VM>> = Mutex::new(Vec::new());
-}
-
-pub fn init_shm_ring(base: usize) {
-    SHM_RING.call_once(|| {
-        let h = unsafe { ShmRingHandle::from_base(base) };
-        Mutex::new(h)
-    });
-}
-
-pub fn with_shm_ring<R>(f: impl FnOnce(&ShmRing) -> R) -> R {
-    let m = SHM_RING.get().expect("call init_shm_ring() first");
-    let h = *m.lock();
-    f(h.ring())
-}
-
-pub fn with_shm_ring_mut<R>(f: impl FnOnce(&mut ShmRing) -> R) -> R {
-    let m = SHM_RING.get().expect("call init_shm_ring() first");
-    let mut h = *m.lock();
-    f(h.ring_mut())
 }
 
 struct GlobalAllocator {}

--- a/hypervisor/src/main.rs
+++ b/hypervisor/src/main.rs
@@ -37,13 +37,15 @@ use block::mem_blk::MemBlk;
 use block::virtio_blk::VirtioBlk;
 use core::alloc::{GlobalAlloc, Layout};
 use core::arch::asm;
+use core::marker::PhantomData;
 use core::ptr::NonNull;
 use fdt::DeviceTreeInfo;
 use lazy_static::lazy_static;
 use log::{Level, Metadata, Record};
 use memory::set_pmp_all_physical_address;
 use mmio::ns16550::Uart;
-use spin::Mutex;
+use shmem::ShmRing;
+use spin::{Mutex, Once};
 use string_utils::hex_ptr_to_usize;
 use vector::setup_vector;
 use virtio::{VIRTIO_MMIO_DEFAULT_ADDRESS, VirtioMmio};
@@ -85,15 +87,68 @@ const SHMEM_SIZE: usize = 0x4000000;
 //     set_mie(get_mie() & !(1 << MIE_MEIE_OFFSET));
 // }
 
+#[derive(Clone, Copy)]
+pub struct ShmRingHandle {
+    ptr: NonNull<ShmRing>,
+    _p: PhantomData<&'static ShmRing>,
+}
+
+unsafe impl Send for ShmRingHandle {}
+unsafe impl Sync for ShmRingHandle {}
+
+impl ShmRingHandle {
+    pub unsafe fn from_base(base: usize) -> Self {
+        assert!(
+            base % align_of::<ShmRing>() == 0,
+            "ShmRing alignment mismatch"
+        );
+        let ptr = NonNull::new(base as *mut ShmRing).expect("null shm base");
+        Self {
+            ptr,
+            _p: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn ring(&self) -> &ShmRing {
+        unsafe { self.ptr.as_ref() }
+    }
+
+    #[inline]
+    pub fn ring_mut(&mut self) -> &mut ShmRing {
+        unsafe { self.ptr.as_mut() }
+    }
+}
+
 static LOGGER: SimpleLogger = SimpleLogger;
 static MEMORY_ALLOCATOR: Mutex<allocator::Heap<33>> = Mutex::new(allocator::Heap::new());
 static VIRTUAL_UART_DEVICE: Mutex<Uart> = Mutex::new(Uart::new());
 static CURRENT_VMID: Mutex<usize> = Mutex::new(0);
+static SHM_RING: Once<Mutex<ShmRingHandle>> = Once::new();
 #[cfg(feature = "nested_support")]
 static HOST_HYPERVISOR_CSR: Mutex<HypervisorCsr> = Mutex::new(HypervisorCsr::new());
 
 lazy_static! {
     pub static ref VIRTUAL_MACHINES: Mutex<Vec<VM>> = Mutex::new(Vec::new());
+}
+
+pub fn init_shm_ring(base: usize) {
+    SHM_RING.call_once(|| {
+        let h = unsafe { ShmRingHandle::from_base(base) };
+        Mutex::new(h)
+    });
+}
+
+pub fn with_shm_ring<R>(f: impl FnOnce(&ShmRing) -> R) -> R {
+    let m = SHM_RING.get().expect("call init_shm_ring() first");
+    let h = *m.lock();
+    f(h.ring())
+}
+
+pub fn with_shm_ring_mut<R>(f: impl FnOnce(&mut ShmRing) -> R) -> R {
+    let m = SHM_RING.get().expect("call init_shm_ring() first");
+    let mut h = *m.lock();
+    f(h.ring_mut())
 }
 
 struct GlobalAllocator {}

--- a/hypervisor/src/main.rs
+++ b/hypervisor/src/main.rs
@@ -13,6 +13,7 @@ mod memory;
 mod paging;
 mod plic;
 mod sbi;
+mod timer;
 mod vector;
 mod vm;
 mod virtual_devices {
@@ -285,6 +286,7 @@ extern "C" fn main(argc: usize, argv: *const *const u8) -> usize {
     mideleg |= MIE_MEIE as u64;
     mideleg |= MIE_VSEIE as u64;
     mideleg |= XIE_SEIE as u64;
+    mideleg |= XIE_STIE as u64;
     set_mideleg(mideleg);
     println!("[setup] mideleg: {:#X}", mideleg);
 
@@ -308,6 +310,10 @@ extern "C" fn main(argc: usize, argv: *const *const u8) -> usize {
     let mut hie = get_hie();
     hie |= XIE_SEIE as u64;
     set_hie(hie);
+
+    let mut menvcfg = get_menvcfg();
+    menvcfg |= MENVCFG_STCE as u64;
+    set_menvcfg(menvcfg);
 
     let mut mstatus = get_mstatus();
     mstatus |= MSTATUS_SIE as u64;

--- a/hypervisor/src/main.rs
+++ b/hypervisor/src/main.rs
@@ -125,6 +125,7 @@ static MEMORY_ALLOCATOR: Mutex<allocator::Heap<33>> = Mutex::new(allocator::Heap
 static VIRTUAL_UART_DEVICE: Mutex<Uart> = Mutex::new(Uart::new());
 static CURRENT_VMID: Mutex<usize> = Mutex::new(0);
 static SHM_RING: Once<Mutex<ShmRingHandle>> = Once::new();
+static BUFFER_COUNT: Mutex<usize> = Mutex::new(0);
 #[cfg(feature = "nested_support")]
 static HOST_HYPERVISOR_CSR: Mutex<HypervisorCsr> = Mutex::new(HypervisorCsr::new());
 

--- a/hypervisor/src/main.rs
+++ b/hypervisor/src/main.rs
@@ -50,7 +50,7 @@ pub mod shmem_handle {
     impl ShmRingHandle {
         pub unsafe fn from_base(base: usize) -> Self {
             assert!(
-                base % align_of::<ShmRing>() == 0,
+                base % core::mem::align_of::<ShmRing>() == 0,
                 "ShmRing alignment mismatch"
             );
             let ptr = core::ptr::NonNull::new(base as *mut ShmRing).expect("null shm base");

--- a/hypervisor/src/nested.rs
+++ b/hypervisor/src/nested.rs
@@ -132,8 +132,6 @@ pub fn hypervisor_csr_access(
     }
 
     vms[current_vmid].hypervisor = Some(l1_hypervisor);
-
-    return;
 }
 
 #[cfg(feature = "nested_acceleration")]

--- a/hypervisor/src/nested.rs
+++ b/hypervisor/src/nested.rs
@@ -1,0 +1,305 @@
+use crate::paging;
+use crate::println;
+use crate::vm::VM;
+use crate::vm::switch_vm_context;
+use alloc::vec::Vec;
+use arch::riscv::cpu::csr_address::CSR_HGATP_ADDRESS;
+use arch::riscv::cpu::*;
+use arch::riscv::instruction::CsrAccessInstructionType;
+use spin::MutexGuard;
+#[cfg(feature = "nested_acceleration")]
+use {
+    crate::BUFFER_COUNT,
+    crate::shmem_handle::*,
+    crate::timer::{TIMER_FRQ, disable_timer_intr, start_timer},
+    crate::vector::{E_STORE_AMO_GUEST_PAGE_FAULT, I_VIRTUAL_SUPERVISOR_SOFTWARE},
+    arch::riscv::instruction,
+};
+use {
+    crate::HOST_HYPERVISOR_CSR, crate::emulate_csr::HypervisorCsr, crate::emulate_csr::emulate_csr,
+    crate::vm::HypervisorContext,
+};
+
+#[cfg(feature = "nested_acceleration")]
+const TARGET_ADDRESS: usize = 0x10000000;
+#[cfg(feature = "nested_acceleration")]
+const FLUSH_INTERVAL: usize = 5;
+
+pub fn assert_l1_hypervisor(sp: usize, vscause: u64, vsepc: u64, vstval: u64, sepc: u64) -> ! {
+    set_vscause(vscause);
+    set_vsepc(vsepc);
+    set_vstval(vstval);
+    set_sepc(sepc);
+
+    unsafe extern "C" {
+        fn vm_entry(sp: usize);
+    }
+    unsafe {
+        vm_entry(sp);
+    }
+    // don't return to here
+    unreachable!()
+}
+
+pub fn store_l0_hypervisor_context() {
+    let mut locked_csr = HOST_HYPERVISOR_CSR.lock();
+    let host_csr = HypervisorCsr {
+        hstatus: get_hstatus(),
+        hedeleg: get_hedeleg(),
+        hideleg: get_hideleg(),
+        hie: get_hie(),
+        hcounteren: get_hcounteren(),
+        hgeie: get_hgeie(),
+        htval: get_htval(),
+        hip: get_hip(),
+        hvip: get_hvip(),
+        htinst: get_htinst(),
+        henvcfg: get_henvcfg(),
+        hgatp: get_hgatp(),
+    };
+    *locked_csr = host_csr;
+}
+
+pub fn load_hypervisor_context(csr: HypervisorCsr) {
+    set_hstatus(csr.hstatus);
+    set_hedeleg(csr.hedeleg);
+    set_hideleg(csr.hideleg);
+    set_hie(csr.hie);
+    set_hcounteren(csr.hcounteren);
+    set_hgeie(csr.hgeie);
+    set_htval(csr.htval);
+    set_hip(csr.hip);
+    set_hvip(csr.hvip);
+    set_htinst(csr.htinst);
+    set_henvcfg(csr.henvcfg);
+    set_hgatp(csr.hgatp);
+}
+
+pub fn create_l2_vm(parent_vmid: usize, vms: &mut Vec<VM>) -> usize {
+    let new_vmid = vms.len();
+    let l2_vm = VM::new(new_vmid, 0, 0, 0, 0, 0, 0, Vec::new(), Some(parent_vmid));
+    vms.push(l2_vm);
+
+    new_vmid
+}
+
+pub fn hypervisor_csr_access(
+    registers: &mut [u64],
+    current_vmid: usize,
+    vms: &mut Vec<VM>,
+    csr_address: usize,
+    access_type: CsrAccessInstructionType,
+    src: usize,
+    dst: usize,
+) {
+    // Access to a Hypervisor CSR from an L1 implies that
+    // a hypervisor is running within the L1 VM.
+    let mut l1_hypervisor = match vms[current_vmid].hypervisor {
+        Some(context) => context,
+        None => {
+            let vmid = create_l2_vm(current_vmid, vms);
+            HypervisorContext {
+                csr: HypervisorCsr::new(),
+                vmid,
+            }
+        }
+    };
+    let write_value = match access_type {
+        CsrAccessInstructionType::CSRRW => registers[src],
+        CsrAccessInstructionType::CSRRS => {
+            let reg_value = registers[src];
+            let csr_value = l1_hypervisor.csr.get_csr(csr_address);
+            csr_value | reg_value
+        }
+    };
+
+    emulate_csr(&mut l1_hypervisor, csr_address, dst, write_value, registers);
+
+    if csr_address == CSR_HGATP_ADDRESS {
+        let l2_vmid = l1_hypervisor.vmid;
+        match paging::shadow_map_address_stage2(true, true, true, l1_hypervisor.csr.hgatp) {
+            Ok(table_address) => {
+                vms[l2_vmid].page_table_address = table_address;
+            }
+            Err(err) => {
+                println!(
+                    "Error: Failed to create shadow page table for L2 VM: {}",
+                    err
+                );
+                return;
+            }
+        }
+    }
+
+    vms[current_vmid].hypervisor = Some(l1_hypervisor);
+
+    return;
+}
+
+#[cfg(feature = "nested_acceleration")]
+pub fn timer_flush_to_l1(
+    sp: usize,
+    mut mutex_vmid: MutexGuard<'_, usize>,
+    mut mutex_vms: MutexGuard<'_, Vec<VM>>,
+) {
+    if let Some(parent_vmid) = mutex_vms[*mutex_vmid].parent_vmid {
+        disable_timer_intr();
+        load_hypervisor_context(*(HOST_HYPERVISOR_CSR.lock()));
+        switch_vm_context(parent_vmid, &mut mutex_vmid, &mut mutex_vms);
+    } else {
+        // print!(".");
+        start_timer((FLUSH_INTERVAL * TIMER_FRQ) as u64);
+        return;
+    }
+    let csr = mutex_vms[*mutex_vmid].vcsr;
+
+    drop(mutex_vmid);
+    drop(mutex_vms);
+
+    assert_l1_hypervisor(
+        sp,
+        I_VIRTUAL_SUPERVISOR_SOFTWARE as u64,
+        get_sepc(),
+        TARGET_ADDRESS as u64,
+        csr.stvec,
+    );
+}
+
+pub fn reflect_to_l1(
+    sp: usize,
+    mut mutex_vmid: MutexGuard<'_, usize>,
+    mut mutex_vms: MutexGuard<'_, Vec<VM>>,
+    parent_vmid: usize,
+) {
+    // return to L2
+    #[cfg(feature = "nested_acceleration")]
+    if get_scause() as usize == E_STORE_AMO_GUEST_PAGE_FAULT
+        && get_stval() as usize == TARGET_ADDRESS
+    {
+        let contexts = unsafe { &mut *core::ptr::slice_from_raw_parts_mut(sp as *mut u64, 32) };
+        let instruction = instruction::Instruction::new(get_htinst() as u32);
+        let rs2 = instruction.get_rs2();
+        let byte = contexts[rs2] as u8;
+
+        with_shm_ring_mut(|r| {
+            r.push(&[byte]);
+        });
+
+        let mut cnt = BUFFER_COUNT.lock();
+        *cnt += 1;
+        let do_flush = *cnt > 16 || byte == b'\n';
+        if do_flush {
+            *cnt = 0;
+        }
+        drop(cnt);
+
+        let inst_len = if instruction.is_compression_instruction() {
+            2
+        } else {
+            4
+        };
+
+        if do_flush {
+            load_hypervisor_context(*(HOST_HYPERVISOR_CSR.lock()));
+            switch_vm_context(parent_vmid, &mut mutex_vmid, &mut mutex_vms);
+
+            let csr = mutex_vms[parent_vmid].vcsr;
+
+            drop(mutex_vmid);
+            drop(mutex_vms);
+
+            assert_l1_hypervisor(
+                sp,
+                I_VIRTUAL_SUPERVISOR_SOFTWARE as u64,
+                get_sepc() + inst_len,
+                TARGET_ADDRESS as u64,
+                csr.stvec,
+            );
+        }
+
+        start_timer((FLUSH_INTERVAL * TIMER_FRQ) as u64);
+
+        set_sepc(get_sepc() + inst_len);
+
+        return;
+    }
+
+    // assert to L1
+    load_hypervisor_context(*(HOST_HYPERVISOR_CSR.lock()));
+    switch_vm_context(parent_vmid, &mut mutex_vmid, &mut mutex_vms);
+
+    // println!("↓L2 VM ↑L1 VMM");
+    if let Some(hypervisor) = mutex_vms[parent_vmid].hypervisor.as_mut() {
+        hypervisor.csr.htinst = get_htinst();
+        hypervisor.csr.htval = get_htval();
+    } else {
+        panic!("No L1 Hypervisor.");
+    }
+
+    let csr = mutex_vms[parent_vmid].vcsr;
+
+    drop(mutex_vmid);
+    drop(mutex_vms);
+
+    assert_l1_hypervisor(sp, get_scause(), get_sepc(), get_stval(), csr.stvec);
+    // don't return to here.
+}
+
+pub fn l1_to_l2(
+    sp: usize,
+    mut mutex_vmid: MutexGuard<'_, usize>,
+    mut mutex_vms: MutexGuard<'_, Vec<VM>>,
+) {
+    // println!("↓L1 VM ↑L2 VM");
+    let current_vmid = *mutex_vmid;
+    // L1 Hypervisor trying to context switching to L2 VM
+    let l1_hypervisor = match mutex_vms[current_vmid].hypervisor {
+        Some(hypervisor) => hypervisor,
+        None => {
+            let vmid = create_l2_vm(current_vmid, &mut mutex_vms);
+            HypervisorContext {
+                csr: HypervisorCsr::new(),
+                vmid,
+            }
+        }
+    };
+    let l2_vmid = l1_hypervisor.vmid;
+    if l1_hypervisor.csr.hstatus as usize & HSTATUS_SPV == 0 {
+        // L1 Hypervisor must be set this bit
+        panic!("Invalid SRET");
+    }
+
+    // Switch Hypervisor Context from L0 to L1
+    store_l0_hypervisor_context();
+    load_hypervisor_context(l1_hypervisor.csr);
+
+    // Switch Page Table from L1 VM to L2 VM
+    let table_address = mutex_vms[l1_hypervisor.vmid].page_table_address;
+    let mut hgatp = match paging::DEFAULT_TABLE_LEVEL {
+        3 => 0b1000 << 60,
+        4 => 0b1001 << 60,
+        5 => 0b1010 << 60,
+        _ => unreachable!(),
+    };
+    hgatp |= (table_address >> 12) & SATP_PPN_MASK;
+    set_hgatp(hgatp as u64);
+
+    // Set L2 VM entry point
+    set_sepc(get_vsepc());
+
+    // println!("L2 VM entry point: {:#x}", get_vsepc() as usize);
+
+    // Change Current VMID from L1 VM to L2 VM
+    switch_vm_context(l2_vmid, &mut mutex_vmid, &mut mutex_vms);
+
+    drop(mutex_vmid);
+    drop(mutex_vms);
+
+    unsafe extern "C" {
+        fn vm_entry(sp: usize);
+    }
+    unsafe {
+        vm_entry(sp);
+    }
+    // don't return to here
+}

--- a/hypervisor/src/timer.rs
+++ b/hypervisor/src/timer.rs
@@ -1,5 +1,7 @@
 use arch::riscv::cpu::*;
 
+pub const TIMER_FRQ: usize = 10000;
+
 pub fn enable_timer_intr() {
     set_sie(get_sie() | XIE_STIE as u64);
 }
@@ -10,5 +12,5 @@ pub fn disable_timer_intr() {
 
 pub fn start_timer(value: u64) {
     set_stimecmp(get_time().wrapping_add(value));
-    enable_timer_intr()
+    enable_timer_intr();
 }

--- a/hypervisor/src/timer.rs
+++ b/hypervisor/src/timer.rs
@@ -1,0 +1,14 @@
+use arch::riscv::cpu::*;
+
+pub fn enable_timer_intr() {
+    set_sie(get_sie() | XIE_STIE as u64);
+}
+
+pub fn disable_timer_intr() {
+    set_sie(get_sie() & !(XIE_STIE as u64));
+}
+
+pub fn start_timer(value: u64) {
+    set_stimecmp(get_time().wrapping_add(value));
+    enable_timer_intr()
+}

--- a/hypervisor/src/vector.rs
+++ b/hypervisor/src/vector.rs
@@ -1,29 +1,21 @@
-use crate::BUFFER_COUNT;
 use crate::CURRENT_VMID;
 use crate::VIRTUAL_MACHINES;
 use crate::mmio::ns16550;
+#[cfg(feature = "nested_acceleration")]
+use crate::nested::timer_flush_to_l1;
+#[cfg(feature = "nested_support")]
+use crate::nested::{hypervisor_csr_access, l1_to_l2, reflect_to_l1};
 use crate::paging;
 use crate::plic;
 use crate::println;
 use crate::sbi;
-use crate::timer::TIMER_FRQ;
-use crate::timer::disable_timer_intr;
-use crate::timer::start_timer;
-use crate::vm::{Csr, VM};
-use crate::with_shm_ring_mut;
+use crate::vm::VM;
 use alloc::vec::Vec;
-use arch::riscv::cpu::csr_address::CSR_HGATP_ADDRESS;
 use arch::riscv::cpu::csr_address::CSR_TIME_ADDRESS;
-use arch::riscv::instruction::CsrAccessInstructionType;
 use arch::riscv::{cpu::*, instruction, instruction::Instruction};
 use core::arch::global_asm;
 use mmio_core::MmioEntry;
 use spin::MutexGuard;
-#[cfg(feature = "nested_support")]
-use {
-    crate::HOST_HYPERVISOR_CSR, crate::emulate_csr::HypervisorCsr, crate::emulate_csr::emulate_csr,
-    crate::vm::HypervisorContext, crate::vm::create_l2_vm,
-};
 
 pub const E_ILLEGAL_INSTRUCTION: usize = 2;
 pub const E_INSTRUCTION_GUEST_PAGE_FAULT: usize = 20;
@@ -34,12 +26,11 @@ pub const E_ENVIRONMENT_CALL_FROM_VS_MODE: usize = 10;
 
 pub const INTERRUPT_ID: usize = 1 << (MXLEN - 1);
 
+#[cfg(feature = "nested_acceleration")]
 pub const I_VIRTUAL_SUPERVISOR_SOFTWARE: usize = 2 | INTERRUPT_ID;
+#[cfg(feature = "nested_acceleration")]
 pub const I_SUPERVISOR_TIMER: usize = 5 | INTERRUPT_ID;
 pub const I_MACHINE_EXTERNAL: usize = 11 | INTERRUPT_ID;
-
-const TARGET_ADDRESS: usize = 0x10000000;
-const FLUSH_INTERVAL: usize = 5;
 
 global_asm!(include_str!("./trap.S"));
 
@@ -52,11 +43,11 @@ pub fn setup_vector() {
     unsafe { set_stvec((&supervisor_vector_table as *const _ as usize) as u64) }
 }
 
-fn is_data_abort(scause: usize) -> bool {
+pub fn is_data_abort(scause: usize) -> bool {
     scause == E_STORE_AMO_GUEST_PAGE_FAULT || scause == E_LOAD_GUEST_PAGE_FAULT
 }
 
-fn is_instruction_abort(scause: usize) -> bool {
+pub fn is_instruction_abort(scause: usize) -> bool {
     scause == E_ILLEGAL_INSTRUCTION
         || scause == E_VIRTUAL_INSTRUCTION
         || scause == E_ENVIRONMENT_CALL_FROM_VS_MODE
@@ -102,119 +93,26 @@ pub fn exception_handler(sp: usize) {
         Some(vms) => vms,
         None => panic!("VIRTUAL_MACHINES is locked."),
     };
-    let mut locked_current_vmid = CURRENT_VMID.lock();
+    let locked_current_vmid = CURRENT_VMID.lock();
 
     let scause = get_scause() as usize;
-    let stval = get_stval() as usize;
     let contexts = unsafe { &mut *core::ptr::slice_from_raw_parts_mut(sp as *mut u64, 32) };
 
+    #[cfg(feature = "nested_acceleration")]
     if scause == I_SUPERVISOR_TIMER {
-        if let Some(parent_vmid) = locked_vm[*locked_current_vmid].parent_vmid {
-            disable_timer_intr();
-            load_hypervisor_context(*(HOST_HYPERVISOR_CSR.lock()));
-            switch_vm_context(parent_vmid, &mut locked_current_vmid, &mut locked_vm);
-        } else {
-            // print!(".");
-            start_timer((FLUSH_INTERVAL * TIMER_FRQ) as u64);
-            return;
-        }
-        let csr = locked_vm[*locked_current_vmid].vcsr;
-
-        drop(locked_current_vmid);
-        drop(locked_vm);
-
-        assert_l1_hypervisor(
-            sp,
-            I_VIRTUAL_SUPERVISOR_SOFTWARE as u64,
-            get_sepc(),
-            TARGET_ADDRESS as u64,
-            csr.stvec,
-        );
+        timer_flush_to_l1(sp, locked_current_vmid, locked_vm);
+        return;
     }
 
     #[cfg(feature = "nested_support")]
     match locked_vm[*locked_current_vmid].parent_vmid {
         Some(parent_vmid) => {
-            // return to L2
-            if scause == E_STORE_AMO_GUEST_PAGE_FAULT && stval == TARGET_ADDRESS {
-                let instruction = instruction::Instruction::new(get_htinst() as u32);
-                let rs2 = instruction.get_rs2();
-                let byte = contexts[rs2] as u8;
-
-                with_shm_ring_mut(|r| {
-                    r.push(&[byte]);
-                });
-
-                let mut cnt = BUFFER_COUNT.lock();
-                *cnt += 1;
-                let do_flush = *cnt > 16 || byte == b'\n';
-                if do_flush {
-                    *cnt = 0;
-                }
-                drop(cnt);
-
-                let inst_len = if instruction.is_compression_instruction() {
-                    2
-                } else {
-                    4
-                };
-
-                if do_flush {
-                    load_hypervisor_context(*(HOST_HYPERVISOR_CSR.lock()));
-                    switch_vm_context(parent_vmid, &mut locked_current_vmid, &mut locked_vm);
-
-                    let csr = locked_vm[parent_vmid].vcsr;
-
-                    drop(locked_current_vmid);
-                    drop(locked_vm);
-
-                    assert_l1_hypervisor(
-                        sp,
-                        I_VIRTUAL_SUPERVISOR_SOFTWARE as u64,
-                        get_sepc() + inst_len,
-                        TARGET_ADDRESS as u64,
-                        csr.stvec,
-                    );
-                }
-
-                start_timer((FLUSH_INTERVAL * TIMER_FRQ) as u64);
-
-                set_sepc(get_sepc() + inst_len);
-
+            reflect_to_l1(sp, locked_current_vmid, locked_vm, parent_vmid);
+            if cfg!(feature = "nested_acceleration") {
                 return;
-            }
-
-            // assert to L1
-            load_hypervisor_context(*(HOST_HYPERVISOR_CSR.lock()));
-            switch_vm_context(parent_vmid, &mut locked_current_vmid, &mut locked_vm);
-
-            // println!("↓L2 VM ↑L1 VMM");
-            if let Some(hypervisor) = locked_vm[parent_vmid].hypervisor.as_mut() {
-                hypervisor.csr.htinst = get_htinst();
-                hypervisor.csr.htval = get_htval();
             } else {
-                panic!("No L1 Hypervisor.");
+                unreachable!()
             }
-
-            let csr = locked_vm[parent_vmid].vcsr;
-
-            drop(locked_current_vmid);
-            drop(locked_vm);
-
-            if is_data_abort(scause) {
-                // Assert Page Fault to L1 Hypervisor
-                assert_l1_hypervisor(sp, get_scause(), get_sepc(), get_stval(), csr.stvec);
-                // TODO: Consider that L1 changed page table.
-            } else if is_instruction_abort(scause) {
-                assert_l1_hypervisor(sp, get_scause(), get_sepc(), get_stval(), csr.stvec);
-            } else {
-                println!("Exception from S-Mode has occured!");
-                println!("[info] scause: {:#X}", get_scause());
-                println!("[info] stval: {:#X}", get_stval());
-
-                panic!();
-            }
-            // don't return to here.
         }
         None => {
             // L1 VM
@@ -308,7 +206,7 @@ fn instruction_abort_handler(
     sp: usize,
     scause: usize,
     registers: &mut [u64],
-    mut mutex_vmid: MutexGuard<'_, usize>,
+    mutex_vmid: MutexGuard<'_, usize>,
     mut mutex_vms: MutexGuard<'_, Vec<VM>>,
 ) {
     let current_vmid = *mutex_vmid;
@@ -336,52 +234,15 @@ fn instruction_abort_handler(
 
                 #[cfg(feature = "nested_support")]
                 if csr_address::is_hypervisor_csr(csr_address) {
-                    // Access to a Hypervisor CSR from an L1 implies that
-                    // a hypervisor is running within the L1 VM.
-                    let mut l1_hypervisor = match vms[current_vmid].hypervisor {
-                        Some(context) => context,
-                        None => {
-                            let vmid = create_l2_vm(current_vmid, vms);
-                            HypervisorContext {
-                                csr: HypervisorCsr::new(),
-                                vmid,
-                            }
-                        }
-                    };
-                    let write_value = match access_type {
-                        CsrAccessInstructionType::CSRRW => registers[rs1],
-                        CsrAccessInstructionType::CSRRS => {
-                            let reg_value = registers[rs1];
-                            let csr_value = l1_hypervisor.csr.get_csr(csr_address);
-                            csr_value | reg_value
-                        }
-                    };
-
-                    emulate_csr(&mut l1_hypervisor, csr_address, rd, write_value, registers);
-
-                    if csr_address == CSR_HGATP_ADDRESS {
-                        let l2_vmid = l1_hypervisor.vmid;
-                        match paging::shadow_map_address_stage2(
-                            true,
-                            true,
-                            true,
-                            l1_hypervisor.csr.hgatp,
-                        ) {
-                            Ok(table_address) => {
-                                vms[l2_vmid].page_table_address = table_address;
-                            }
-                            Err(err) => {
-                                println!(
-                                    "Error: Failed to create shadow page table for L2 VM: {}",
-                                    err
-                                );
-                                return;
-                            }
-                        }
-                    }
-
-                    vms[current_vmid].hypervisor = Some(l1_hypervisor);
-
+                    hypervisor_csr_access(
+                        registers,
+                        current_vmid,
+                        vms,
+                        csr_address,
+                        access_type,
+                        rs1,
+                        rd,
+                    );
                     return;
                 }
 
@@ -396,57 +257,8 @@ fn instruction_abort_handler(
             }
             #[cfg(feature = "nested_support")]
             if instruction.is_sret() {
-                // println!("↓L1 VM ↑L2 VM");
-                // L1 Hypervisor trying to context switching to L2 VM
-                let l1_hypervisor = match vms[current_vmid].hypervisor {
-                    Some(hypervisor) => hypervisor,
-                    None => {
-                        let vmid = create_l2_vm(current_vmid, vms);
-                        HypervisorContext {
-                            csr: HypervisorCsr::new(),
-                            vmid,
-                        }
-                    }
-                };
-                let l2_vmid = l1_hypervisor.vmid;
-                if l1_hypervisor.csr.hstatus as usize & HSTATUS_SPV == 0 {
-                    // L1 Hypervisor must be set this bit
-                    panic!("Invalid SRET");
-                }
-
-                // Switch Hypervisor Context from L0 to L1
-                store_l0_hypervisor_context();
-                load_hypervisor_context(l1_hypervisor.csr);
-
-                // Switch Page Table from L1 VM to L2 VM
-                let table_address = vms[l1_hypervisor.vmid].page_table_address;
-                let mut hgatp = match paging::DEFAULT_TABLE_LEVEL {
-                    3 => 0b1000 << 60,
-                    4 => 0b1001 << 60,
-                    5 => 0b1010 << 60,
-                    _ => unreachable!(),
-                };
-                hgatp |= (table_address >> 12) & SATP_PPN_MASK;
-                set_hgatp(hgatp as u64);
-
-                // Set L2 VM entry point
-                set_sepc(get_vsepc());
-
-                // println!("L2 VM entry point: {:#x}", get_vsepc() as usize);
-
-                // Change Current VMID from L1 VM to L2 VM
-                switch_vm_context(l2_vmid, &mut mutex_vmid, &mut mutex_vms);
-
-                drop(mutex_vmid);
-                drop(mutex_vms);
-
-                unsafe extern "C" {
-                    fn vm_entry(sp: usize);
-                }
-                unsafe {
-                    vm_entry(sp);
-                }
-                // don't return to here
+                l1_to_l2(sp, mutex_vmid, mutex_vms);
+                unreachable!()
             }
 
             println!("[info] VIRTUAL INSTRUCTION: {:#x}", get_stval());
@@ -479,86 +291,4 @@ fn instruction_abort_handler(
             panic!();
         }
     };
-}
-
-fn switch_vm_context(
-    vmid: usize,
-    mutex_vmid: &mut MutexGuard<'_, usize>,
-    mutex_vms: &mut MutexGuard<'_, Vec<VM>>,
-) {
-    let current_vm = &mut (*mutex_vms)[**mutex_vmid];
-
-    let csr = Csr {
-        stvec: get_vstvec(),
-        sepc: get_vsepc(),
-        sstatus: get_vsstatus(),
-        scause: get_vscause(),
-        stval: get_vstval(),
-        satp: get_vsatp(),
-    };
-    current_vm.vcsr = csr;
-
-    let next_csr = (*mutex_vms)[vmid].vcsr;
-
-    set_vstvec(next_csr.stvec);
-    set_vsepc(next_csr.sepc);
-    set_vsstatus(next_csr.sstatus);
-    set_vscause(next_csr.scause);
-    set_vstval(next_csr.stval);
-    set_vsatp(next_csr.satp);
-
-    **mutex_vmid = vmid;
-}
-
-#[cfg(feature = "nested_support")]
-fn assert_l1_hypervisor(sp: usize, vscause: u64, vsepc: u64, vstval: u64, sepc: u64) -> ! {
-    set_vscause(vscause);
-    set_vsepc(vsepc);
-    set_vstval(vstval);
-    set_sepc(sepc);
-
-    unsafe extern "C" {
-        fn vm_entry(sp: usize);
-    }
-    unsafe {
-        vm_entry(sp);
-    }
-    // don't return to here
-    unreachable!()
-}
-
-#[cfg(feature = "nested_support")]
-fn store_l0_hypervisor_context() {
-    let mut locked_csr = HOST_HYPERVISOR_CSR.lock();
-    let host_csr = HypervisorCsr {
-        hstatus: get_hstatus(),
-        hedeleg: get_hedeleg(),
-        hideleg: get_hideleg(),
-        hie: get_hie(),
-        hcounteren: get_hcounteren(),
-        hgeie: get_hgeie(),
-        htval: get_htval(),
-        hip: get_hip(),
-        hvip: get_hvip(),
-        htinst: get_htinst(),
-        henvcfg: get_henvcfg(),
-        hgatp: get_hgatp(),
-    };
-    *locked_csr = host_csr;
-}
-
-#[cfg(feature = "nested_support")]
-fn load_hypervisor_context(csr: HypervisorCsr) {
-    set_hstatus(csr.hstatus);
-    set_hedeleg(csr.hedeleg);
-    set_hideleg(csr.hideleg);
-    set_hie(csr.hie);
-    set_hcounteren(csr.hcounteren);
-    set_hgeie(csr.hgeie);
-    set_htval(csr.htval);
-    set_hip(csr.hip);
-    set_hvip(csr.hvip);
-    set_htinst(csr.htinst);
-    set_henvcfg(csr.henvcfg);
-    set_hgatp(csr.hgatp);
 }

--- a/hypervisor/src/vector.rs
+++ b/hypervisor/src/vector.rs
@@ -6,8 +6,8 @@ use crate::paging;
 use crate::plic;
 use crate::println;
 use crate::sbi;
+use crate::timer::TIMER_FRQ;
 use crate::timer::disable_timer_intr;
-use crate::timer::enable_timer_intr;
 use crate::timer::start_timer;
 use crate::vm::{Csr, VM};
 use crate::with_shm_ring_mut;
@@ -115,7 +115,7 @@ pub fn exception_handler(sp: usize) {
             switch_vm_context(parent_vmid, &mut locked_current_vmid, &mut locked_vm);
         } else {
             // print!(".");
-            start_timer(FLUSH_INTERVAL as u64 * 10000);
+            start_timer((FLUSH_INTERVAL * TIMER_FRQ) as u64);
             return;
         }
         let csr = locked_vm[*locked_current_vmid].vcsr;
@@ -177,7 +177,7 @@ pub fn exception_handler(sp: usize) {
                     );
                 }
 
-                start_timer((FLUSH_INTERVAL * 10000) as u64);
+                start_timer((FLUSH_INTERVAL * TIMER_FRQ) as u64);
 
                 set_sepc(get_sepc() + inst_len);
 
@@ -189,7 +189,6 @@ pub fn exception_handler(sp: usize) {
             switch_vm_context(parent_vmid, &mut locked_current_vmid, &mut locked_vm);
 
             // println!("↓L2 VM ↑L1 VMM");
-            let csr = locked_vm[parent_vmid].vcsr;
             if let Some(hypervisor) = locked_vm[parent_vmid].hypervisor.as_mut() {
                 hypervisor.csr.htinst = get_htinst();
                 hypervisor.csr.htval = get_htval();

--- a/hypervisor/src/vector.rs
+++ b/hypervisor/src/vector.rs
@@ -30,10 +30,13 @@ pub const E_STORE_AMO_GUEST_PAGE_FAULT: usize = 23;
 pub const E_ENVIRONMENT_CALL_FROM_VS_MODE: usize = 10;
 
 pub const INTERRUPT_ID: usize = 1 << (MXLEN - 1);
-pub const I_MACHINE_EXTERNAL: usize = 11 | INTERRUPT_ID;
+
 pub const I_VIRTUAL_SUPERVISOR_SOFTWARE: usize = 2 | INTERRUPT_ID;
+pub const I_SUPERVISOR_TIMER: usize = 5 | INTERRUPT_ID;
+pub const I_MACHINE_EXTERNAL: usize = 11 | INTERRUPT_ID;
 
 const TARGET_ADDRESS: usize = 0x10000000;
+const FLUSH_INTERVAL: usize = 300;
 
 global_asm!(include_str!("./trap.S"));
 
@@ -99,67 +102,75 @@ pub fn exception_handler(sp: usize) {
     let mut locked_current_vmid = CURRENT_VMID.lock();
 
     let scause = get_scause() as usize;
+    let stval = get_stval() as usize;
     let contexts = unsafe { &mut *core::ptr::slice_from_raw_parts_mut(sp as *mut u64, 32) };
+
+    if scause == I_SUPERVISOR_TIMER {
+        if let Some(parent_vmid) = locked_vm[*locked_current_vmid].parent_vmid {
+            load_hypervisor_context(*(HOST_HYPERVISOR_CSR.lock()));
+            switch_vm_context(parent_vmid, &mut locked_current_vmid, &mut locked_vm);
+        }
+
+        
+    }
 
     #[cfg(feature = "nested_support")]
     match locked_vm[*locked_current_vmid].parent_vmid {
         Some(parent_vmid) => {
-            if is_data_abort(scause) {
+            // return to L2
+            if scause == E_STORE_AMO_GUEST_PAGE_FAULT && stval == TARGET_ADDRESS {
                 let instruction = instruction::Instruction::new(get_htinst() as u32);
-                if scause == E_STORE_AMO_GUEST_PAGE_FAULT {
-                    let stval = get_stval() as usize;
-                    if stval == TARGET_ADDRESS {
-                        let rs2 = instruction.get_rs2();
-                        let byte = contexts[rs2] as u8;
+                let rs2 = instruction.get_rs2();
+                let byte = contexts[rs2] as u8;
 
-                        with_shm_ring_mut(|r| {
-                            r.push(&[byte]);
-                        });
+                with_shm_ring_mut(|r| {
+                    r.push(&[byte]);
+                });
 
-                        let mut cnt = BUFFER_COUNT.lock();
-                        *cnt += 1;
-                        let do_flush = *cnt > 16 || byte == b'\n';
-                        if do_flush {
-                            *cnt = 0;
-                        }
-                        drop(cnt);
-
-                        if do_flush {
-                            load_hypervisor_context(*(HOST_HYPERVISOR_CSR.lock()));
-                            switch_vm_context(
-                                parent_vmid,
-                                &mut locked_current_vmid,
-                                &mut locked_vm,
-                            );
-
-                            let csr = locked_vm[parent_vmid].vcsr;
-
-                            drop(locked_current_vmid);
-                            drop(locked_vm);
-
-                            assert_l1_hypervisor(
-                                sp,
-                                I_VIRTUAL_SUPERVISOR_SOFTWARE as u64,
-                                get_sepc(),
-                                TARGET_ADDRESS as u64,
-                                csr.stvec,
-                            );
-                        }
-
-                        let inst_len = if instruction.is_compression_instruction() {
-                            2
-                        } else {
-                            4
-                        };
-                        set_sepc(get_sepc() + inst_len);
-                        return;
-                    }
+                let mut cnt = BUFFER_COUNT.lock();
+                *cnt += 1;
+                let do_flush = *cnt > 16 || byte == b'\n';
+                if do_flush {
+                    *cnt = 0;
                 }
-            }
-            // Switch Hypervisor Context from L1 to L0
-            load_hypervisor_context(*(HOST_HYPERVISOR_CSR.lock()));
+                drop(cnt);
 
-            // Change Current VMID from L2 VM to L1 VM
+                if do_flush {
+                    load_hypervisor_context(*(HOST_HYPERVISOR_CSR.lock()));
+                    switch_vm_context(
+                        parent_vmid,
+                        &mut locked_current_vmid,
+                        &mut locked_vm,
+                    );
+
+                    let csr = locked_vm[parent_vmid].vcsr;
+
+                    drop(locked_current_vmid);
+                    drop(locked_vm);
+
+                    assert_l1_hypervisor(
+                        sp,
+                        I_VIRTUAL_SUPERVISOR_SOFTWARE as u64,
+                        get_sepc(),
+                        TARGET_ADDRESS as u64,
+                        csr.stvec,
+                    );
+                }
+
+                start_timer((FLUSH_INTERVAL * 10000) as u64);
+
+                let inst_len = if instruction.is_compression_instruction() {
+                    2
+                } else {
+                    4
+                };
+                set_sepc(get_sepc() + inst_len);
+
+                return;
+            }
+
+            // assert to L1
+            load_hypervisor_context(*(HOST_HYPERVISOR_CSR.lock()));
             switch_vm_context(parent_vmid, &mut locked_current_vmid, &mut locked_vm);
 
             // println!("↓L2 VM ↑L1 VMM");
@@ -170,6 +181,8 @@ pub fn exception_handler(sp: usize) {
             } else {
                 panic!("No L1 Hypervisor.");
             }
+
+            let csr = locked_vm[parent_vmid].vcsr;
 
             drop(locked_current_vmid);
             drop(locked_vm);

--- a/hypervisor/src/vector.rs
+++ b/hypervisor/src/vector.rs
@@ -118,7 +118,7 @@ pub fn exception_handler(sp: usize) {
 
                         let mut cnt = BUFFER_COUNT.lock();
                         *cnt += 1;
-                        let do_flush = *cnt > 256 || byte == b'\n';
+                        let do_flush = *cnt > 16 || byte == b'\n';
                         if do_flush {
                             *cnt = 0;
                         }

--- a/hypervisor/src/vector.rs
+++ b/hypervisor/src/vector.rs
@@ -4,8 +4,12 @@ use crate::VIRTUAL_MACHINES;
 use crate::mmio::ns16550;
 use crate::paging;
 use crate::plic;
+use crate::print;
 use crate::println;
 use crate::sbi;
+use crate::timer::disable_timer_intr;
+use crate::timer::enable_timer_intr;
+use crate::timer::start_timer;
 use crate::vm::{Csr, VM};
 use crate::with_shm_ring_mut;
 use alloc::vec::Vec;
@@ -36,7 +40,7 @@ pub const I_SUPERVISOR_TIMER: usize = 5 | INTERRUPT_ID;
 pub const I_MACHINE_EXTERNAL: usize = 11 | INTERRUPT_ID;
 
 const TARGET_ADDRESS: usize = 0x10000000;
-const FLUSH_INTERVAL: usize = 300;
+const FLUSH_INTERVAL: usize = 100;
 
 global_asm!(include_str!("./trap.S"));
 
@@ -107,11 +111,26 @@ pub fn exception_handler(sp: usize) {
 
     if scause == I_SUPERVISOR_TIMER {
         if let Some(parent_vmid) = locked_vm[*locked_current_vmid].parent_vmid {
+            disable_timer_intr();
             load_hypervisor_context(*(HOST_HYPERVISOR_CSR.lock()));
             switch_vm_context(parent_vmid, &mut locked_current_vmid, &mut locked_vm);
+        } else {
+            print!(".");
+            start_timer(FLUSH_INTERVAL as u64 * 10000);
+            return;
         }
+        let csr = locked_vm[*locked_current_vmid].vcsr;
 
-        
+        drop(locked_current_vmid);
+        drop(locked_vm);
+
+        assert_l1_hypervisor(
+            sp,
+            I_VIRTUAL_SUPERVISOR_SOFTWARE as u64,
+            get_sepc(),
+            TARGET_ADDRESS as u64,
+            csr.stvec,
+        );
     }
 
     #[cfg(feature = "nested_support")]
@@ -135,13 +154,15 @@ pub fn exception_handler(sp: usize) {
                 }
                 drop(cnt);
 
+                let inst_len = if instruction.is_compression_instruction() {
+                    2
+                } else {
+                    4
+                };
+
                 if do_flush {
                     load_hypervisor_context(*(HOST_HYPERVISOR_CSR.lock()));
-                    switch_vm_context(
-                        parent_vmid,
-                        &mut locked_current_vmid,
-                        &mut locked_vm,
-                    );
+                    switch_vm_context(parent_vmid, &mut locked_current_vmid, &mut locked_vm);
 
                     let csr = locked_vm[parent_vmid].vcsr;
 
@@ -151,7 +172,7 @@ pub fn exception_handler(sp: usize) {
                     assert_l1_hypervisor(
                         sp,
                         I_VIRTUAL_SUPERVISOR_SOFTWARE as u64,
-                        get_sepc(),
+                        get_sepc() + inst_len,
                         TARGET_ADDRESS as u64,
                         csr.stvec,
                     );
@@ -159,11 +180,6 @@ pub fn exception_handler(sp: usize) {
 
                 start_timer((FLUSH_INTERVAL * 10000) as u64);
 
-                let inst_len = if instruction.is_compression_instruction() {
-                    2
-                } else {
-                    4
-                };
                 set_sepc(get_sepc() + inst_len);
 
                 return;

--- a/hypervisor/src/vector.rs
+++ b/hypervisor/src/vector.rs
@@ -1,3 +1,4 @@
+use crate::BUFFER_COUNT;
 use crate::CURRENT_VMID;
 use crate::VIRTUAL_MACHINES;
 use crate::mmio::ns16550;
@@ -6,6 +7,7 @@ use crate::plic;
 use crate::println;
 use crate::sbi;
 use crate::vm::{Csr, VM};
+use crate::with_shm_ring_mut;
 use alloc::vec::Vec;
 use arch::riscv::cpu::csr_address::CSR_HGATP_ADDRESS;
 use arch::riscv::cpu::csr_address::CSR_TIME_ADDRESS;
@@ -29,6 +31,9 @@ pub const E_ENVIRONMENT_CALL_FROM_VS_MODE: usize = 10;
 
 pub const INTERRUPT_ID: usize = 1 << (MXLEN - 1);
 pub const I_MACHINE_EXTERNAL: usize = 11 | INTERRUPT_ID;
+pub const I_VIRTUAL_SUPERVISOR_SOFTWARE: usize = 2 | INTERRUPT_ID;
+
+const TARGET_ADDRESS: usize = 0x10000000;
 
 global_asm!(include_str!("./trap.S"));
 
@@ -94,10 +99,63 @@ pub fn exception_handler(sp: usize) {
     let mut locked_current_vmid = CURRENT_VMID.lock();
 
     let scause = get_scause() as usize;
+    let contexts = unsafe { &mut *core::ptr::slice_from_raw_parts_mut(sp as *mut u64, 32) };
 
     #[cfg(feature = "nested_support")]
     match locked_vm[*locked_current_vmid].parent_vmid {
         Some(parent_vmid) => {
+            if is_data_abort(scause) {
+                let instruction = instruction::Instruction::new(get_htinst() as u32);
+                if scause == E_STORE_AMO_GUEST_PAGE_FAULT {
+                    let stval = get_stval() as usize;
+                    if stval == TARGET_ADDRESS {
+                        let rs2 = instruction.get_rs2();
+                        let byte = contexts[rs2] as u8;
+
+                        with_shm_ring_mut(|r| {
+                            r.push(&[byte]);
+                        });
+
+                        let mut cnt = BUFFER_COUNT.lock();
+                        *cnt += 1;
+                        let do_flush = *cnt > 256 || byte == b'\n';
+                        if do_flush {
+                            *cnt = 0;
+                        }
+                        drop(cnt);
+
+                        if do_flush {
+                            load_hypervisor_context(*(HOST_HYPERVISOR_CSR.lock()));
+                            switch_vm_context(
+                                parent_vmid,
+                                &mut locked_current_vmid,
+                                &mut locked_vm,
+                            );
+
+                            let csr = locked_vm[parent_vmid].vcsr;
+
+                            drop(locked_current_vmid);
+                            drop(locked_vm);
+
+                            assert_l1_hypervisor(
+                                sp,
+                                I_VIRTUAL_SUPERVISOR_SOFTWARE as u64,
+                                get_sepc(),
+                                TARGET_ADDRESS as u64,
+                                csr.stvec,
+                            );
+                        }
+
+                        let inst_len = if instruction.is_compression_instruction() {
+                            2
+                        } else {
+                            4
+                        };
+                        set_sepc(get_sepc() + inst_len);
+                        return;
+                    }
+                }
+            }
             // Switch Hypervisor Context from L1 to L0
             load_hypervisor_context(*(HOST_HYPERVISOR_CSR.lock()));
 
@@ -122,17 +180,20 @@ pub fn exception_handler(sp: usize) {
                 // TODO: Consider that L1 changed page table.
             } else if is_instruction_abort(scause) {
                 assert_l1_hypervisor(sp, get_scause(), get_sepc(), get_stval(), csr.stvec);
-            }
+            } else {
+                println!("Exception from S-Mode has occured!");
+                println!("[info] scause: {:#X}", get_scause());
+                println!("[info] stval: {:#X}", get_stval());
 
+                panic!();
+            }
             // don't return to here.
-            panic!();
         }
         None => {
             // L1 VM
         }
     }
 
-    let contexts = unsafe { &mut *core::ptr::slice_from_raw_parts_mut(sp as *mut u64, 32) };
     if is_data_abort(scause) {
         // data abort
         let vm = &mut locked_vm[*locked_current_vmid];
@@ -423,7 +484,7 @@ fn switch_vm_context(
 }
 
 #[cfg(feature = "nested_support")]
-fn assert_l1_hypervisor(sp: usize, vscause: u64, vsepc: u64, vstval: u64, sepc: u64) {
+fn assert_l1_hypervisor(sp: usize, vscause: u64, vsepc: u64, vstval: u64, sepc: u64) -> ! {
     set_vscause(vscause);
     set_vsepc(vsepc);
     set_vstval(vstval);
@@ -436,6 +497,7 @@ fn assert_l1_hypervisor(sp: usize, vscause: u64, vsepc: u64, vstval: u64, sepc: 
         vm_entry(sp);
     }
     // don't return to here
+    unreachable!()
 }
 
 #[cfg(feature = "nested_support")]

--- a/hypervisor/src/vector.rs
+++ b/hypervisor/src/vector.rs
@@ -4,7 +4,6 @@ use crate::VIRTUAL_MACHINES;
 use crate::mmio::ns16550;
 use crate::paging;
 use crate::plic;
-use crate::print;
 use crate::println;
 use crate::sbi;
 use crate::timer::disable_timer_intr;
@@ -40,7 +39,7 @@ pub const I_SUPERVISOR_TIMER: usize = 5 | INTERRUPT_ID;
 pub const I_MACHINE_EXTERNAL: usize = 11 | INTERRUPT_ID;
 
 const TARGET_ADDRESS: usize = 0x10000000;
-const FLUSH_INTERVAL: usize = 100;
+const FLUSH_INTERVAL: usize = 5;
 
 global_asm!(include_str!("./trap.S"));
 
@@ -115,7 +114,7 @@ pub fn exception_handler(sp: usize) {
             load_hypervisor_context(*(HOST_HYPERVISOR_CSR.lock()));
             switch_vm_context(parent_vmid, &mut locked_current_vmid, &mut locked_vm);
         } else {
-            print!(".");
+            // print!(".");
             start_timer(FLUSH_INTERVAL as u64 * 10000);
             return;
         }

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -1,14 +1,9 @@
 extern crate alloc;
 
-use crate::SHMEM_SIZE;
-use crate::SHMEM_VIRTUAL_ADDRESS;
 use crate::VIRTUAL_MACHINES;
 #[cfg(feature = "nested_support")]
 use crate::emulate_csr::HypervisorCsr;
-use crate::init_shm_ring;
 use crate::paging;
-use crate::paging::PAGE_SIZE;
-use crate::paging::add_mapping_stage2;
 use crate::println;
 use alloc::string::ToString;
 use alloc::vec::Vec;
@@ -149,22 +144,27 @@ pub fn create_vm<T: BlockDevice>(
     hgatp |= (table_address >> 12) & SATP_PPN_MASK;
     set_hgatp(hgatp as u64);
 
-    let shmem_address = allocate_pages(SHMEM_SIZE / PAGE_SIZE, PAGE_SIZE);
-    if shmem_address.is_null() {
-        panic!("Out of memory for share memory.");
+    #[cfg(feature = "nested_acceleration")]
+    {
+        use crate::shmem_handle::*;
+
+        let shmem_address = allocate_pages(SHMEM_SIZE / paging::PAGE_SIZE, paging::PAGE_SIZE);
+        if shmem_address.is_null() {
+            panic!("Out of memory for share memory.");
+        }
+        paging::add_mapping_stage2(
+            shmem_address as usize,
+            SHMEM_VIRTUAL_ADDRESS,
+            SHMEM_SIZE,
+            table_address,
+            paging::DEFAULT_TABLE_LEVEL,
+            true,
+            true,
+            true,
+        )
+        .expect("Failed to mapping");
+        init_shm_ring(shmem_address as usize);
     }
-    add_mapping_stage2(
-        shmem_address as usize,
-        SHMEM_VIRTUAL_ADDRESS,
-        SHMEM_SIZE,
-        table_address,
-        paging::DEFAULT_TABLE_LEVEL,
-        true,
-        true,
-        true,
-    )
-    .expect("Failed to mapping");
-    init_shm_ring(shmem_address as usize);
 
     unsafe {
         riscv64::hfence_gvma_all();
@@ -233,11 +233,27 @@ pub fn create_vm<T: BlockDevice>(
     vmid
 }
 
-#[cfg(feature = "nested_support")]
-pub fn create_l2_vm(parent_vmid: usize, vms: &mut Vec<VM>) -> usize {
-    let new_vmid = vms.len();
-    let l2_vm = VM::new(new_vmid, 0, 0, 0, 0, 0, 0, Vec::new(), Some(parent_vmid));
-    vms.push(l2_vm);
+pub fn switch_vm_context(vmid: usize, current_vmid: &mut usize, vms: &mut Vec<VM>) {
+    let current_vm = &mut vms[*current_vmid];
 
-    new_vmid
+    let csr = Csr {
+        stvec: get_vstvec(),
+        sepc: get_vsepc(),
+        sstatus: get_vsstatus(),
+        scause: get_vscause(),
+        stval: get_vstval(),
+        satp: get_vsatp(),
+    };
+    current_vm.vcsr = csr;
+
+    let next_csr = vms[vmid].vcsr;
+
+    set_vstvec(next_csr.stvec);
+    set_vsepc(next_csr.sepc);
+    set_vsstatus(next_csr.sstatus);
+    set_vscause(next_csr.scause);
+    set_vstval(next_csr.stval);
+    set_vsatp(next_csr.satp);
+
+    *current_vmid = vmid;
 }

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -1,9 +1,13 @@
 extern crate alloc;
 
+use crate::SHMEM_SIZE;
+use crate::SHMEM_VIRTUAL_ADDRESS;
 use crate::VIRTUAL_MACHINES;
 #[cfg(feature = "nested_support")]
 use crate::emulate_csr::HypervisorCsr;
 use crate::paging;
+use crate::paging::PAGE_SIZE;
+use crate::paging::add_mapping_stage2;
 use crate::println;
 use alloc::string::ToString;
 use alloc::vec::Vec;
@@ -143,6 +147,23 @@ pub fn create_vm<T: BlockDevice>(
     };
     hgatp |= (table_address >> 12) & SATP_PPN_MASK;
     set_hgatp(hgatp as u64);
+
+    let shmem_address = allocate_pages(SHMEM_SIZE / PAGE_SIZE, PAGE_SIZE);
+    if shmem_address.is_null() {
+        panic!("Out of memory for share memory.");
+    }
+    add_mapping_stage2(
+        shmem_address as usize,
+        SHMEM_VIRTUAL_ADDRESS,
+        SHMEM_SIZE,
+        table_address,
+        paging::DEFAULT_TABLE_LEVEL,
+        true,
+        true,
+        true,
+    )
+    .expect("Failed to mapping");
+
     unsafe {
         riscv64::hfence_gvma_all();
         riscv64::hfence_vvma_all();

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -5,6 +5,7 @@ use crate::SHMEM_VIRTUAL_ADDRESS;
 use crate::VIRTUAL_MACHINES;
 #[cfg(feature = "nested_support")]
 use crate::emulate_csr::HypervisorCsr;
+use crate::init_shm_ring;
 use crate::paging;
 use crate::paging::PAGE_SIZE;
 use crate::paging::add_mapping_stage2;
@@ -163,6 +164,7 @@ pub fn create_vm<T: BlockDevice>(
         true,
     )
     .expect("Failed to mapping");
+    init_shm_ring(shmem_address as usize);
 
     unsafe {
         riscv64::hfence_gvma_all();

--- a/l1_hypervisor/Cargo.toml
+++ b/l1_hypervisor/Cargo.toml
@@ -12,6 +12,7 @@ fat32 = { version = "0.1.0", path = "../support/fat32" }
 fdt.workspace = true
 lazy_static = { version = "1.5.0", features = ["spin_no_std"] }
 mmio_core = { version = "0.1.0", path = "../support/mmio_core" }
+shmem = { version = "0.1.0", path = "../support/shmem" }
 spin = "0.10.0"
 string_utils.workspace = true
 virtio = { version = "0.1.0", path = "../support/devices/virtio" }

--- a/l1_hypervisor/src/main.rs
+++ b/l1_hypervisor/src/main.rs
@@ -53,6 +53,7 @@ const MAX_MEMORY_ENTRIES: usize = 32;
 const MAX_MMIO_ENTRIES: usize = 64;
 
 const SHMEM_ADDRESS: usize = 0xb0000000;
+#[allow(dead_code)]
 const SHMEM_SIZE: usize = 0x4000000;
 
 // fn intr_disable() {
@@ -269,6 +270,8 @@ extern "C" fn main(argc: usize, argv: *const *const u8) -> usize {
         entry_point = vm.get_entry_point() as usize;
         dtb_pointer = vm.get_dtb_pointer();
     }
+
+    init_shm_ring(SHMEM_ADDRESS);
 
     println!("switch to guest");
     hs_to_vs(entry_point, stack_pointer, dtb_pointer)

--- a/l1_hypervisor/src/main.rs
+++ b/l1_hypervisor/src/main.rs
@@ -50,6 +50,9 @@ macro_rules! bitmask {
 const MAX_MEMORY_ENTRIES: usize = 32;
 const MAX_MMIO_ENTRIES: usize = 64;
 
+const SHMEM_ADDRESS: usize = 0xb0000000;
+const SHMEM_SIZE: usize = 0x4000000;
+
 // fn intr_disable() {
 //     set_mie(get_mie() & !(1 << MIE_MEIE_OFFSET));
 // }

--- a/l1_hypervisor/src/main.rs
+++ b/l1_hypervisor/src/main.rs
@@ -28,10 +28,12 @@ use arch::riscv::sbi;
 use block::virtio_blk::VirtioBlk;
 use core::alloc::{GlobalAlloc, Layout};
 use core::arch::asm;
+use core::marker::PhantomData;
 use core::ptr::NonNull;
 use fdt::DeviceTreeInfo;
 use lazy_static::lazy_static;
-use spin::Mutex;
+use shmem::ShmRing;
+use spin::{Mutex, Once};
 use string_utils::hex_ptr_to_usize;
 use vector::setup_vector;
 use virtio::VirtioMmio;
@@ -57,11 +59,64 @@ const SHMEM_SIZE: usize = 0x4000000;
 //     set_mie(get_mie() & !(1 << MIE_MEIE_OFFSET));
 // }
 
+#[derive(Clone, Copy)]
+pub struct ShmRingHandle {
+    ptr: NonNull<ShmRing>,
+    _p: PhantomData<&'static ShmRing>,
+}
+
+unsafe impl Send for ShmRingHandle {}
+unsafe impl Sync for ShmRingHandle {}
+
+impl ShmRingHandle {
+    pub unsafe fn from_base(base: usize) -> Self {
+        assert!(
+            base % align_of::<ShmRing>() == 0,
+            "ShmRing alignment mismatch"
+        );
+        let ptr = NonNull::new(base as *mut ShmRing).expect("null shm base");
+        Self {
+            ptr,
+            _p: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn ring(&self) -> &ShmRing {
+        unsafe { self.ptr.as_ref() }
+    }
+
+    #[inline]
+    pub fn ring_mut(&mut self) -> &mut ShmRing {
+        unsafe { self.ptr.as_mut() }
+    }
+}
+
 static MEMORY_ALLOCATOR: Mutex<allocator::Heap<33>> = Mutex::new(allocator::Heap::new());
+static SHM_RING: Once<Mutex<ShmRingHandle>> = Once::new();
 static CURRENT_VMID: Mutex<usize> = Mutex::new(0);
 
 lazy_static! {
     pub static ref VIRTUAL_MACHINES: Mutex<Vec<VM>> = Mutex::new(Vec::new());
+}
+
+pub fn init_shm_ring(base: usize) {
+    SHM_RING.call_once(|| {
+        let h = unsafe { ShmRingHandle::from_base(base) };
+        Mutex::new(h)
+    });
+}
+
+pub fn with_shm_ring<R>(f: impl FnOnce(&ShmRing) -> R) -> R {
+    let m = SHM_RING.get().expect("call init_shm_ring() first");
+    let h = *m.lock();
+    f(h.ring())
+}
+
+pub fn with_shm_ring_mut<R>(f: impl FnOnce(&mut ShmRing) -> R) -> R {
+    let m = SHM_RING.get().expect("call init_shm_ring() first");
+    let mut h = *m.lock();
+    f(h.ring_mut())
 }
 
 struct GlobalAllocator {}

--- a/l1_hypervisor/src/vector.rs
+++ b/l1_hypervisor/src/vector.rs
@@ -61,8 +61,8 @@ pub fn exception_handler(sp: usize) {
     } else if scause == I_VIRTUAL_SUPERVISOR_SOFTWARE {
         let buf = with_shm_ring(|r| {
             let mut buf = [0u8; 256];
-            let _ = r.pop(&mut buf);
-            buf
+            let n = r.pop(&mut buf);
+            buf[0..n].to_vec()
         });
         let vm = &mut locked_vm[*locked_current_vmid];
         let mmio_list = &mut vm.mmio;

--- a/l1_hypervisor/src/vector.rs
+++ b/l1_hypervisor/src/vector.rs
@@ -69,6 +69,7 @@ pub fn exception_handler(sp: usize) {
         for byte in buf {
             write_access(get_stval() as usize, byte as u64, mmio_list);
         }
+        return;
     } else {
         println!("Exception from S-Mode has occured!");
         println!("[info] scause: {:#X}", get_scause());

--- a/l1_hypervisor/src/vector.rs
+++ b/l1_hypervisor/src/vector.rs
@@ -1,8 +1,11 @@
 use crate::CURRENT_VMID;
 use crate::VIRTUAL_MACHINES;
 use crate::paging;
+use crate::print;
 use crate::println;
 use crate::sbi;
+use crate::with_shm_ring;
+use alloc::string::String;
 use alloc::vec::Vec;
 
 use arch::riscv::cpu::csr_address::CSR_TIME_ADDRESS;
@@ -15,6 +18,9 @@ pub const E_LOAD_GUEST_PAGE_FAULT: usize = 21;
 pub const E_VIRTUAL_INSTRUCTION: usize = 22;
 pub const E_STORE_AMO_GUEST_PAGE_FAULT: usize = 23;
 pub const E_ENVIRONMENT_CALL_FROM_VS_MODE: usize = 10;
+
+pub const INTERRUPT_ID: usize = 1 << (MXLEN - 1);
+pub const I_VIRTUAL_SUPERVISOR_SOFTWARE: usize = 2 | INTERRUPT_ID;
 
 global_asm!(include_str!("./trap.S"));
 
@@ -54,6 +60,13 @@ pub fn exception_handler(sp: usize) {
     } else if is_instruction_abort(scause) {
         // instruction abort
         instruction_abort_handler(scause, contexts);
+    } else if scause == I_VIRTUAL_SUPERVISOR_SOFTWARE {
+        let str = with_shm_ring(|r| {
+            let mut buf = [0u8; 256];
+            let n = r.pop(&mut buf);
+            String::from_utf8(buf[0..n].to_vec()).expect("Failed to convert utf8 to String")
+        });
+        print!("{}", str);
     } else {
         println!("Exception from S-Mode has occured!");
         println!("[info] scause: {:#X}", get_scause());

--- a/l1_hypervisor/src/vector.rs
+++ b/l1_hypervisor/src/vector.rs
@@ -11,13 +11,10 @@ use core::arch::global_asm;
 use mmio_core::MmioEntry;
 
 pub const E_ILLEGAL_INSTRUCTION: usize = 2;
-pub const E_INSTRUCTION_GUEST_PAGE_FAULT: usize = 20;
 pub const E_LOAD_GUEST_PAGE_FAULT: usize = 21;
 pub const E_VIRTUAL_INSTRUCTION: usize = 22;
 pub const E_STORE_AMO_GUEST_PAGE_FAULT: usize = 23;
 pub const E_ENVIRONMENT_CALL_FROM_VS_MODE: usize = 10;
-
-pub const INTERRUPT_ID: usize = 1 << (MXLEN - 1);
 
 global_asm!(include_str!("./trap.S"));
 

--- a/l1_hypervisor/src/vector.rs
+++ b/l1_hypervisor/src/vector.rs
@@ -1,11 +1,9 @@
 use crate::CURRENT_VMID;
 use crate::VIRTUAL_MACHINES;
 use crate::paging;
-use crate::print;
 use crate::println;
 use crate::sbi;
 use crate::with_shm_ring;
-use alloc::string::String;
 use alloc::vec::Vec;
 
 use arch::riscv::cpu::csr_address::CSR_TIME_ADDRESS;
@@ -61,12 +59,16 @@ pub fn exception_handler(sp: usize) {
         // instruction abort
         instruction_abort_handler(scause, contexts);
     } else if scause == I_VIRTUAL_SUPERVISOR_SOFTWARE {
-        let str = with_shm_ring(|r| {
+        let buf = with_shm_ring(|r| {
             let mut buf = [0u8; 256];
-            let n = r.pop(&mut buf);
-            String::from_utf8(buf[0..n].to_vec()).expect("Failed to convert utf8 to String")
+            let _ = r.pop(&mut buf);
+            buf
         });
-        print!("{}", str);
+        let vm = &mut locked_vm[*locked_current_vmid];
+        let mmio_list = &mut vm.mmio;
+        for byte in buf {
+            write_access(get_stval() as usize, byte as u64, mmio_list);
+        }
     } else {
         println!("Exception from S-Mode has occured!");
         println!("[info] scause: {:#X}", get_scause());

--- a/l1_hypervisor/src/vector.rs
+++ b/l1_hypervisor/src/vector.rs
@@ -66,8 +66,9 @@ pub fn exception_handler(sp: usize) {
         });
         let vm = &mut locked_vm[*locked_current_vmid];
         let mmio_list = &mut vm.mmio;
+        let stval = get_stval() as usize;
         for byte in buf {
-            write_access(get_stval() as usize, byte as u64, mmio_list);
+            write_access(stval, byte as u64, mmio_list);
         }
         return;
     } else {

--- a/support/shmem/Cargo.toml
+++ b/support/shmem/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "shmem"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/support/shmem/src/lib.rs
+++ b/support/shmem/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 use core::cell::UnsafeCell;
 use core::cmp::min;
 use core::sync::atomic::{AtomicU32, Ordering};

--- a/support/shmem/src/lib.rs
+++ b/support/shmem/src/lib.rs
@@ -1,0 +1,298 @@
+use core::cell::UnsafeCell;
+use core::cmp::min;
+use core::sync::atomic::{AtomicU32, Ordering};
+
+const PAGE_SIZE: usize = 4096;
+const HEADER_SIZE: usize = 8; // head(u32) + tail(u32)
+const BUF_LEN: usize = PAGE_SIZE - HEADER_SIZE; // 4088 bytes
+
+/// Shared-memory ring buffer (SPSC).
+///
+/// # Concurrency contract (IMPORTANT)
+/// - `push()` must be called only by the *single producer* (e.g. hypervisor).
+/// - `pop()`  must be called only by the *single consumer* (e.g. VM).
+/// - If you need MPSC/MPMC, you need a different design (locks or CAS loops).
+#[repr(C)]
+pub struct ShmRing {
+    head: AtomicU32, // consumer advances head
+    tail: AtomicU32, // producer advances tail
+    buf: UnsafeCell<[u8; BUF_LEN]>,
+}
+
+// We provide Sync because interior mutation is controlled by SPSC + atomics ordering.
+unsafe impl Sync for ShmRing {}
+
+impl ShmRing {
+    pub const fn new() -> Self {
+        Self {
+            head: AtomicU32::new(0),
+            tail: AtomicU32::new(0),
+            buf: UnsafeCell::new([0u8; BUF_LEN]),
+        }
+    }
+
+    #[inline]
+    pub const fn capacity(&self) -> u32 {
+        BUF_LEN as u32
+    }
+
+    /// How many bytes are currently stored (readable).
+    #[inline]
+    pub fn readable_len(&self) -> u32 {
+        let cap = self.capacity();
+        let head = self.head.load(Ordering::Acquire);
+        let tail = self.tail.load(Ordering::Acquire);
+        if tail >= head {
+            tail - head
+        } else {
+            cap - (head - tail)
+        }
+    }
+
+    /// How many bytes can be written right now.
+    /// We keep 1 byte empty to distinguish full vs empty.
+    #[inline]
+    pub fn writable_len(&self) -> u32 {
+        let cap = self.capacity();
+        let used = self.readable_len();
+        cap - used - 1
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.readable_len() == 0
+    }
+
+    #[inline]
+    pub fn is_full(&self) -> bool {
+        self.writable_len() == 0
+    }
+
+    /// Producer: push bytes into the ring.
+    /// Returns how many bytes were actually written (0..=data.len()).
+    pub fn push(&self, data: &[u8]) -> usize {
+        let cap = self.capacity() as usize;
+        if cap == 0 || data.is_empty() {
+            return 0;
+        }
+
+        // Producer reads head (written by consumer). Acquire pairs with consumer's head.store(Release).
+        let head = self.head.load(Ordering::Acquire) as usize;
+        // Producer's own tail can be Relaxed (only producer writes it).
+        let tail = self.tail.load(Ordering::Relaxed) as usize;
+
+        // used = distance(head -> tail) in ring space
+        let used = if tail >= head {
+            tail - head
+        } else {
+            cap - (head - tail)
+        };
+
+        // Keep one byte empty.
+        let free = cap - used - 1;
+        if free == 0 {
+            return 0;
+        }
+
+        let n = min(data.len(), free);
+
+        // Two-chunk copy to handle wrap-around.
+        let first = min(n, cap - tail);
+        let second = n - first;
+
+        unsafe {
+            let buf = &mut *self.buf.get();
+            buf[tail..tail + first].copy_from_slice(&data[..first]);
+            if second != 0 {
+                buf[..second].copy_from_slice(&data[first..first + second]);
+            }
+        }
+
+        // Publish the written data by updating tail with Release.
+        let new_tail = (tail + n) % cap;
+        self.tail.store(new_tail as u32, Ordering::Release);
+        n
+    }
+
+    /// Consumer: pop bytes from the ring into `out`.
+    /// Returns how many bytes were actually read (0..=out.len()).
+    pub fn pop(&self, out: &mut [u8]) -> usize {
+        let cap = self.capacity() as usize;
+        if cap == 0 || out.is_empty() {
+            return 0;
+        }
+
+        // Consumer reads tail (written by producer). Acquire pairs with producer's tail.store(Release).
+        let tail = self.tail.load(Ordering::Acquire) as usize;
+        // Consumer's own head can be Relaxed (only consumer writes it).
+        let head = self.head.load(Ordering::Relaxed) as usize;
+
+        let used = if tail >= head {
+            tail - head
+        } else {
+            cap - (head - tail)
+        };
+
+        if used == 0 {
+            return 0;
+        }
+
+        let n = min(out.len(), used);
+
+        // Two-chunk copy to handle wrap-around.
+        let first = min(n, cap - head);
+        let second = n - first;
+
+        unsafe {
+            let buf = &*self.buf.get();
+            out[..first].copy_from_slice(&buf[head..head + first]);
+            if second != 0 {
+                out[first..first + second].copy_from_slice(&buf[..second]);
+            }
+        }
+
+        // Publish that we've consumed data by updating head with Release.
+        let new_head = (head + n) % cap;
+        self.head.store(new_head as u32, Ordering::Release);
+        n
+    }
+
+    /// Optional: reset (only safe when no concurrent access).
+    pub fn clear(&self) {
+        self.head.store(0, Ordering::Relaxed);
+        self.tail.store(0, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+
+    #[test]
+    fn size_is_one_page() {
+        assert_eq!(core::mem::size_of::<ShmRing>(), 4096);
+        assert_eq!(BUF_LEN, 4096 - 8);
+    }
+
+    #[test]
+    fn basic_push_pop() {
+        let r = ShmRing::new();
+        let msg = b"hello";
+        assert_eq!(r.push(msg), 5);
+
+        let mut out = [0u8; 5];
+        assert_eq!(r.pop(&mut out), 5);
+        assert_eq!(&out, msg);
+
+        assert!(r.is_empty());
+        assert_eq!(r.pop(&mut out), 0);
+    }
+
+    #[test]
+    fn wrap_around_preserves_order() {
+        let r = ShmRing::new();
+        let cap = r.capacity() as usize;
+
+        // Fill close to the end to force wrap on next pushes.
+        let a_len = cap - 20; // keep some room for operations
+        let a: Vec<u8> = (0..a_len).map(|i| (i % 251) as u8).collect();
+        assert_eq!(r.push(&a), a_len);
+
+        // Pop some bytes to move head forward.
+        let pop1 = 200;
+        let mut tmp = vec![0u8; pop1];
+        assert_eq!(r.pop(&mut tmp), pop1);
+        assert_eq!(&tmp[..], &a[..pop1]);
+
+        // Now push more to wrap around.
+        let b_len = 150;
+        let b: Vec<u8> = (0..b_len).map(|i| (200 + i) as u8).collect();
+        assert_eq!(r.push(&b), b_len);
+
+        // Pop remaining from a plus all b, and verify order.
+        let mut out = vec![0u8; (a_len - pop1) + b_len];
+        assert_eq!(r.pop(&mut out), out.len());
+
+        assert_eq!(&out[..a_len - pop1], &a[pop1..]);
+        assert_eq!(&out[a_len - pop1..], &b[..]);
+    }
+
+    #[test]
+    fn full_and_partial_write() {
+        let r = ShmRing::new();
+        let cap = r.capacity() as usize;
+
+        // Max storable is cap-1 (one byte kept empty).
+        let fill = vec![0xAAu8; cap - 1];
+        assert_eq!(r.push(&fill), cap - 1);
+        assert!(r.is_full());
+
+        // Further push should write 0.
+        assert_eq!(r.push(&[1, 2, 3]), 0);
+
+        // Pop some, then push again.
+        let mut out = vec![0u8; 10];
+        assert_eq!(r.pop(&mut out), 10);
+        assert_eq!(out, vec![0xAAu8; 10]);
+
+        let more = vec![0xBBu8; 20];
+        assert_eq!(r.push(&more), 10);
+
+        // Drain and check ordering: remaining AA then BB.
+        let mut drain = vec![0u8; cap - 1];
+        assert_eq!(r.pop(&mut drain), drain.len());
+
+        assert_eq!(
+            &drain[..(cap - 1) - 10],
+            vec![0xAAu8; (cap - 1) - 10].as_slice()
+        );
+        assert_eq!(&drain[(cap - 1) - 10..], vec![0xBBu8; 10].as_slice());
+    }
+
+    #[test]
+    fn concurrent_spsc_stress() {
+        const N: usize = 50_000;
+
+        let ring = Arc::new(ShmRing::new());
+
+        let prod = {
+            let ring = Arc::clone(&ring);
+            thread::spawn(move || {
+                let mut sent = 0usize;
+                while sent < N {
+                    let b = [(sent & 0xFF) as u8];
+                    if ring.push(&b) == 1 {
+                        sent += 1;
+                    } else {
+                        thread::yield_now();
+                    }
+                }
+            })
+        };
+
+        let cons = {
+            let ring = Arc::clone(&ring);
+            thread::spawn(move || {
+                let mut recv = 0usize;
+                let mut out = [0u8; 1];
+                while recv < N {
+                    if ring.pop(&mut out) == 1 {
+                        assert_eq!(out[0], (recv & 0xFF) as u8);
+                        recv += 1;
+                    } else {
+                        thread::yield_now();
+                    }
+                }
+            })
+        };
+
+        prod.join().unwrap();
+        cons.join().unwrap();
+        assert!(ring.is_empty());
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -36,7 +36,7 @@ fn build() -> Result<(), DynError> {
     let target = "riscv64gc-unknown-none-elf";
     // Default settings
     let mut is_release = false;
-    let mut is_nested = false;
+    let mut cargo_features: Vec<String> = Vec::new();
 
     // Path
     let base_output_directory = project_root().join("bin");
@@ -46,14 +46,17 @@ fn build() -> Result<(), DynError> {
 
     let args: Vec<String> = env::args().collect();
     let mut args_iter = args.iter().skip(2);
+
     // Parse options
     while let Some(v) = args_iter.next() {
         if v == "-f" || v == "--features" {
             if let Some(feature_list) = args_iter.next() {
                 for feature in feature_list.split(',') {
-                    let feature_name = feature.trim().to_string();
-                    if feature_name == "nested" {
-                        is_nested = true;
+                    let feature_name = feature.trim();
+                    match feature_name {
+                        "nested" => cargo_features.push("nested_support".to_string()),
+                        "nested_acel" => cargo_features.push("nested_acceleration".to_string()),
+                        _ => cargo_features.push(feature_name.to_string()),
                     }
                 }
             }
@@ -67,7 +70,11 @@ fn build() -> Result<(), DynError> {
 
     fs::create_dir_all(&hypervisor_output_directory)?;
 
-    if is_nested {
+    let need_l1_build = cargo_features
+        .iter()
+        .any(|f| f == "nested_support" || f == "nested_acceleration");
+
+    if need_l1_build {
         fs::create_dir_all(&l1_hypervisor_output_directory)?;
         log::info!("build l1 hypervisor");
         let output_path = l1_hypervisor_output_directory.clone().join("hypervisor");
@@ -112,7 +119,9 @@ fn build() -> Result<(), DynError> {
     } else {
         binary_path.push("debug/hypervisor");
     }
-    build_hypervisor(is_nested, is_release)?;
+
+    build_hypervisor(&cargo_features, is_release)?;
+
     fs::rename(&binary_path, &output_path)?;
 
     // compile device tree script
@@ -138,16 +147,17 @@ fn build() -> Result<(), DynError> {
     Ok(())
 }
 
-fn build_hypervisor(is_nested: bool, is_release: bool) -> Result<(), DynError> {
+fn build_hypervisor(features: &[String], is_release: bool) -> Result<(), DynError> {
     let hypervisor_path = project_root().join("hypervisor");
     let mut hypervisor_cargo_args: Vec<String> = vec!["build".to_string()];
 
     if is_release {
         hypervisor_cargo_args.push("--release".to_string());
     }
-    if is_nested {
+
+    if !features.is_empty() {
         hypervisor_cargo_args.push("--features".to_string());
-        hypervisor_cargo_args.push("nested_support".to_string());
+        hypervisor_cargo_args.push(features.join(","));
     }
 
     let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
@@ -339,10 +349,11 @@ Command List:
   build
   run
 
-  -f, --features [nested]
-                           select options with comma split
+  -f, --features [nested, nested_acel, ...]
+                            select options with comma split
 Examples:
-  cargo xtask build             Build Halycon with default option.
-  cargo xtask build -f nested   Build Halycon with nested support hypervisor and l1_hypervisor."
+  cargo xtask build              Build Halycon with default option.
+  cargo xtask build -f nested    Build Halycon with nested_support.
+  cargo xtask build -f nested_acel    Build Halycon with nested_acceleration."
     )
 }


### PR DESCRIPTION
# Summary
- Add nested virtualization acceleration feature: buffer L2 MMIO (UART) writes in L0 via shared memory and flush to L1 in batches.

## Related Issue / Task
- graduation research: nested virtualization assist / reflection reduction

## What's Changed
- Added shared memory region between L0 and L1 for communication/buffering.
- Implemented L0-side capture of L2 MMIO trap payload (e.g., UART bytes) and buffering into shared memory.
- Added L1 flush notification/handler path to drain shared memory and process output in batches.
- Implemented flush policy:
  - Flush when buffered byte count exceeds a threshold, **or**
  - Flush when no new write has occurred for a fixed timeout (5ms).

## Testing and Review

### **Steps to Test**
1. normal nested virtualization: `cargo xtask build -f nested && cargo xtask run`
2. acceleration: `cargo xtask build -f nested_acel && cargo xtask run`

## Reviewer Checklist
- [ ] Shared memory mapping is correct and isolated to intended L0/L1 paths.
- [ ] L0 buffering does not break MMIO semantics (ordering/newline handling, etc.).
- [ ] Flush trigger logic (threshold/timeout) is correct and race-free.
- [ ] L1 flush path properly drains shared memory and does not introduce extra traps unexpectedly.
- [ ] Hot path avoids heavy logging/locking overhead.

## Additional Notes / Concerns
- This change targets reducing L2→L1 reflection frequency for MMIO-heavy workloads (e.g., UART output) while keeping nested virtualization behavior intact.
