### PR TITLE
feat: provide block device for L2 VM

### DIFF
--- a/l1_hypervisor/Cargo.toml
+++ b/l1_hypervisor/Cargo.toml
@@ -16,3 +16,4 @@ shmem = { version = "0.1.0", path = "../support/shmem" }
 spin = "0.10.0"
 string_utils.workspace = true
 virtio = { version = "0.1.0", path = "../support/devices/virtio" }
+virtio_core = { version = "0.1.0", path = "../support/virtio_core" }

--- a/l1_hypervisor/src/main.rs
+++ b/l1_hypervisor/src/main.rs
@@ -11,6 +11,7 @@ mod plic;
 mod vector;
 mod vm;
 mod virtual_devices {
+    pub mod virtio;
     pub mod serial {
         pub mod ns16550;
     }
@@ -21,10 +22,13 @@ mod mmio {
 
 use crate::mmio::ns16550::NS16550_ADDR;
 use alloc::boxed::Box;
+use alloc::string::ToString;
+use alloc::vec;
 use alloc::vec::Vec;
 use allocate_pages::allocate_pages;
 use arch::riscv::cpu::*;
 use arch::riscv::sbi;
+use block::mem_blk::MemBlk;
 use block::virtio_blk::VirtioBlk;
 use core::alloc::{GlobalAlloc, Layout};
 use core::arch::asm;
@@ -36,7 +40,7 @@ use shmem::ShmRing;
 use spin::{Mutex, Once};
 use string_utils::hex_ptr_to_usize;
 use vector::setup_vector;
-use virtio::VirtioMmio;
+use virtio::{VIRTIO_MMIO_DEFAULT_ADDRESS, VirtioMmio};
 use vm::VM;
 
 // guest device
@@ -203,7 +207,16 @@ extern "C" fn main(argc: usize, argv: *const *const u8) -> usize {
         host_block_device.expect("No block device for hypervisor.")
     };
 
-    let fs = fat32::fat32_init(host_block_device).expect("Failed to init fat32 file system.");
+    let mut fs = fat32::fat32_init(host_block_device).expect("Failed to init fat32 file system.");
+
+    let vm_img_file_name = "VM.IMG".to_string();
+    let file_size = fs
+        .get_file_size(&vm_img_file_name)
+        .expect("Failed to get file size.");
+    let mut buf = vec![0u8; file_size];
+    fs.read_file(&vm_img_file_name, &mut buf)
+        .expect("Failed to read vm disk image.");
+    let mem_block = MemBlk::new(&buf);
 
     // set_mie(get_mie() & (1 << MIE_MEIE_OFFSET));
     // println!("[setup] mie");
@@ -251,6 +264,17 @@ extern "C" fn main(argc: usize, argv: *const *const u8) -> usize {
         Box::new(virtual_devices::serial::ns16550::Ns16550),
     );
     mmio.push(serial_entry);
+
+    let virtio_entry = MmioEntry::new(
+        VIRTIO_MMIO_DEFAULT_ADDRESS,
+        0x1000,
+        Box::new(
+            virtual_devices::virtio::virtio_mmio::VirtioMmioTransport::new(
+                virtual_devices::virtio::virtio_blk::VirtioBlkDevice::new(mem_block),
+            ),
+        ),
+    );
+    mmio.push(virtio_entry);
 
     let stack_size = 0x2000;
     let stack_memory = allocate_pages(stack_size / paging::PAGE_SIZE, paging::PAGE_SIZE);

--- a/l1_hypervisor/src/virtual_devices/virtio/mod.rs
+++ b/l1_hypervisor/src/virtual_devices/virtio/mod.rs
@@ -1,0 +1,2 @@
+pub mod virtio_blk;
+pub mod virtio_mmio;

--- a/l1_hypervisor/src/virtual_devices/virtio/virtio_blk.rs
+++ b/l1_hypervisor/src/virtual_devices/virtio/virtio_blk.rs
@@ -1,0 +1,68 @@
+use block::{BlockDevice, virtio_blk::VirtioBlkReq};
+use virtio::VRingDesc;
+use virtio_core::{VIRTQ_ENTRY_NUM, virtio_blk::VirtioBlkConfig};
+
+use crate::paging::resolve_address_stage2;
+
+use super::virtio_mmio::{VirtioDevice, VirtioMmioRegister};
+
+#[derive(Debug)]
+pub struct VirtioBlkDevice<D: BlockDevice> {
+    block_device: D,
+    mmio_state: VirtioMmioRegister,
+    config: VirtioBlkConfig,
+}
+
+impl<D: BlockDevice> VirtioBlkDevice<D> {
+    pub fn new(block_device: D) -> Self {
+        let capacity = block_device.get_capacity();
+
+        let mut config = VirtioBlkConfig::new();
+        config.capacity = capacity as u64;
+
+        VirtioBlkDevice {
+            block_device,
+            mmio_state: VirtioMmioRegister::new(),
+            config,
+        }
+    }
+}
+
+impl<T: BlockDevice> VirtioDevice for VirtioBlkDevice<T> {
+    fn device_id(&self) -> u32 {
+        2
+    }
+
+    fn notify(&mut self, desc_ring: &[VRingDesc; VIRTQ_ENTRY_NUM as usize]) {
+        let request_address = resolve_address_stage2(desc_ring[0].addr as usize).unwrap();
+        let data_address = resolve_address_stage2(desc_ring[1].addr as usize).unwrap();
+        let status_address = resolve_address_stage2(desc_ring[2].addr as usize).unwrap() as *mut u8;
+        let virtio_blk_req = unsafe { &mut *(request_address as *mut VirtioBlkReq) };
+
+        if desc_ring[1].flags & VRingDesc::VIRTQ_DESC_F_WRITE as u16 != 0 {
+            let count = desc_ring[1].len as usize / block::SECTOR_SIZE;
+            let _ = self.block_device.read_write_disk(
+                data_address as *mut usize,
+                virtio_blk_req.sector,
+                count,
+                false,
+            );
+        }
+
+        unsafe {
+            core::ptr::write_volatile(status_address, block::virtio_blk::VIRTIO_BLK_S_OK as u8);
+        }
+    }
+
+    fn mmio_state(&self) -> &VirtioMmioRegister {
+        &self.mmio_state
+    }
+
+    fn mmio_state_mut(&mut self) -> &mut VirtioMmioRegister {
+        &mut self.mmio_state
+    }
+
+    fn read_config(&self, offset: usize) -> u32 {
+        self.config.read_as_bytes(offset)
+    }
+}

--- a/l1_hypervisor/src/virtual_devices/virtio/virtio_mmio.rs
+++ b/l1_hypervisor/src/virtual_devices/virtio/virtio_mmio.rs
@@ -1,0 +1,168 @@
+use core::fmt::Debug;
+
+use crate::paging::resolve_address_stage2;
+// use crate::println;
+use mmio_core::MmioHandler;
+use virtio::*;
+use virtio_core::*;
+
+pub trait VirtioDevice {
+    fn device_id(&self) -> u32;
+
+    fn notify(&mut self, desc_ring: &[VRingDesc; VIRTQ_ENTRY_NUM as usize]);
+
+    fn mmio_state(&self) -> &VirtioMmioRegister;
+
+    fn mmio_state_mut(&mut self) -> &mut VirtioMmioRegister;
+
+    fn read_config(&self, offset: usize) -> u32;
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct VirtioMmioRegister {
+    pub queue_size: u32,
+    pub queue_sel: u32,
+    pub queue_ready: u32,
+    pub desc_address: u64,
+    pub driver_address: u64,
+    pub device_address: u64,
+    pub status: u32,
+    pub device_features_low: u32,
+    pub device_features_high: u32,
+    pub device_features_sel: u32,
+    pub driver_features_low: u32,
+    pub driver_features_high: u32,
+    pub driver_features_sel: u32,
+}
+
+impl VirtioMmioRegister {
+    pub const fn new() -> Self {
+        VirtioMmioRegister {
+            queue_size: 0,
+            queue_sel: 0,
+            queue_ready: 0,
+            desc_address: 0,
+            driver_address: 0,
+            device_address: 0,
+            status: 0,
+            device_features_low: 0,
+            device_features_high: 1, // A driver MUST accept VIRTIO_F_VERSION_1 if it is offered.
+            device_features_sel: 0,
+            driver_features_low: 0,
+            driver_features_high: 0,
+            driver_features_sel: 0,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct VirtioMmioTransport<D: VirtioDevice> {
+    device: D,
+}
+
+impl<D: VirtioDevice> VirtioMmioTransport<D> {
+    pub fn new(device: D) -> Self {
+        VirtioMmioTransport { device }
+    }
+}
+
+impl<D: VirtioDevice + Debug + Send> MmioHandler for VirtioMmioTransport<D> {
+    fn read(&self, offset: usize) -> usize {
+        let register = self.device.mmio_state();
+
+        const VIRTIO_MMIO_END_OFFSET: usize = VIRTIO_MMIO_SIZE - 4;
+
+        let value = match offset {
+            VIRTIO_MMIO_MAGIC => VIRTIO_MMIO_MAGIC_VALUE,
+            VIRTIO_MMIO_VERSION => VIRTIO_VERSION,
+            VIRTIO_MMIO_DEVICEID => self.device.device_id() as usize,
+            VIRTIO_MMIO_VENDORID => 0,
+            VIRTIO_MMIO_DEVICE_FEATURES => {
+                if register.device_features_sel == 0 {
+                    register.device_features_low as usize
+                } else {
+                    register.device_features_high as usize
+                }
+            }
+            VIRTIO_MMIO_QUEUE_SIZE_MAX => VIRTQ_ENTRY_NUM as usize,
+            VIRTIO_MMIO_QUEUE_READY => register.queue_ready as usize,
+            VIRTIO_MMIO_STATUS => register.status as usize,
+            VIRTIO_MMIO_CONFIG..=VIRTIO_MMIO_END_OFFSET => {
+                let config_offset = offset - VIRTIO_MMIO_CONFIG;
+                self.device.read_config(config_offset) as usize
+            }
+            _ => 0,
+        };
+
+        // println!("read: {:#X}, {:#X}", offset, value);
+        value as usize
+    }
+
+    fn write(&mut self, offset: usize, value: usize) {
+        // println!("write: {:#X}, {:#X}", offset, value as u32);
+
+        match offset {
+            VIRTIO_MMIO_QUEUE_NOTIFY => unsafe {
+                let device = &mut self.device;
+                if value as u32 != device.mmio_state().queue_sel {
+                    // TODO: Set STATUS Register
+                    return;
+                }
+
+                let desc_address =
+                    resolve_address_stage2(device.mmio_state().desc_address as usize).unwrap();
+                let desc_ring_slice = &mut *core::ptr::slice_from_raw_parts_mut(
+                    desc_address as *mut VRingDesc,
+                    VIRTQ_ENTRY_NUM as usize,
+                );
+                let desc_ring: [VRingDesc; VIRTQ_ENTRY_NUM as usize] = desc_ring_slice
+                    .try_into()
+                    .expect("Failed to convert slice to array.");
+
+                device.notify(&desc_ring);
+
+                let device_address =
+                    resolve_address_stage2(device.mmio_state().device_address as usize).unwrap();
+                let used_ring = &mut *(device_address as *mut VRingUsed);
+                used_ring.idx = used_ring.idx.wrapping_add(1);
+            },
+            VIRTIO_MMIO_QUEUE_READY => {}
+            VIRTIO_MMIO_QUEUE_SIZE => {
+                self.device.mmio_state_mut().queue_size = value as u32;
+            }
+            VIRTIO_MMIO_QUEUE_SEL => {
+                self.device.mmio_state_mut().queue_sel = value as u32;
+            }
+            VIRTIO_MMIO_DEVICE_FEATURES_SEL => {
+                self.device.mmio_state_mut().device_features_sel = value as u32;
+            }
+            VIRTIO_MMIO_DRIVER_FEATURES_SEL => {
+                self.device.mmio_state_mut().driver_features_sel = value as u32;
+            }
+            VIRTIO_MMIO_DRIVER_FEATURES => {
+                if self.device.mmio_state().driver_features_sel == 0 {
+                    self.device.mmio_state_mut().driver_features_low = value as u32;
+                } else {
+                    self.device.mmio_state_mut().driver_features_high = value as u32;
+                }
+            }
+            VIRTIO_MMIO_STATUS_FEATURES_OK => {
+                self.device.mmio_state_mut().status |= VIRTIO_MMIO_STATUS_FEATURES_OK as u32;
+            }
+            VIRTIO_MMIO_STATUS => {
+                self.device.mmio_state_mut().status = value as u32;
+            }
+            VIRTIO_MMIO_DESC_LOW => {
+                self.device.mmio_state_mut().desc_address = value as u32 as u64;
+            }
+            VIRTIO_MMIO_DRIVER_LOW => {
+                self.device.mmio_state_mut().driver_address = value as u32 as u64;
+            }
+            VIRTIO_MMIO_DEVICE_LOW => {
+                self.device.mmio_state_mut().device_address = value as u32 as u64;
+            }
+            _ => {}
+        }
+    }
+}

--- a/l1_hypervisor/src/vm.rs
+++ b/l1_hypervisor/src/vm.rs
@@ -84,7 +84,7 @@ impl VM {
 
 pub fn create_vm<T: BlockDevice>(mut fs: Fat32<T>, mmio: Vec<MmioEntry>) -> usize {
     const RAM_VIRTUAL_BASE: usize = 0x80000000;
-    const RAM_SIZE: usize = 0x8000000;
+    const RAM_SIZE: usize = 0x10000000;
 
     let ram_physical_base_address = allocate_pages(RAM_SIZE / paging::PAGE_SIZE, paging::PAGE_SIZE);
     if ram_physical_base_address.is_null() {

--- a/scripts/boot_L2hypervisor.script
+++ b/scripts/boot_L2hypervisor.script
@@ -1,0 +1,1 @@
+echo hello,world

--- a/scripts/virt_L1hypervisor.dts
+++ b/scripts/virt_L1hypervisor.dts
@@ -8,7 +8,7 @@
 
   memory@80000000 {
     device_type = "memory";
-    reg = <0x0 0x80000000 0x0 0x8000000>;
+    reg = <0x0 0x80000000 0x0 0x10000000>;
   };
 
   cpus {
@@ -60,6 +60,11 @@
 		clock-frequency = <0x384000>;
 		reg = <0x0 0x10000000 0x0 0x100>;
 		compatible = "ns16550a";
+  };
+
+  virtio_mmio@10001000 {
+    reg = <0x0 0x10001000 0x0 0x1000>;
+    compatible = "virtio,mmio";
   };
 
   timer {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -42,6 +42,7 @@ fn build() -> Result<(), DynError> {
     let base_output_directory = project_root().join("bin");
     let hypervisor_output_directory = base_output_directory.clone().join("disk");
     let l1_hypervisor_output_directory = base_output_directory.clone().join("l1_disk");
+    let l2_disk = base_output_directory.clone().join("l2_disk");
     let script_path = project_root().join("scripts");
 
     let args: Vec<String> = env::args().collect();
@@ -76,6 +77,7 @@ fn build() -> Result<(), DynError> {
 
     if need_l1_build {
         fs::create_dir_all(&l1_hypervisor_output_directory)?;
+        fs::create_dir_all(&l2_disk)?;
         log::info!("build l1 hypervisor");
         let output_path = l1_hypervisor_output_directory.clone().join("hypervisor");
         let mut binary_path = project_root().join(format!("target/{}", target));
@@ -92,6 +94,19 @@ fn build() -> Result<(), DynError> {
         let dts_path = script_path.clone().join("virt_L1hypervisor.dts");
         let output_path = l1_hypervisor_output_directory.clone().join("virt.dtb");
         device_tree::compile_dts(&dts_path, &output_path)?;
+
+        // compile boot script
+        log::info!("compile u-boot boot script for L2 VM");
+        let binary_path = script_path.clone().join("boot_L2hypervisor.script");
+        let output_path = l2_disk.clone().join("boot.scr");
+        mkimage::uboot_mkimage(&binary_path, &output_path)?;
+
+        let entries = read_dir_entries(&l2_disk)?;
+        let files: Vec<&Path> = entries.iter().map(|e| e.as_path()).collect();
+        create_disk::create_fat32_disk(
+            &l1_hypervisor_output_directory.clone().join("vm.img"),
+            &files,
+        )?;
 
         // compile boot script
         log::info!("compile u-boot boot script for L1 Hypervisor");


### PR DESCRIPTION
# Summary
- provide virtio-blk device for L2 VM

## Related Issue / Task

## What's Changed
- add virtio device support for L1 hypeevisor
- vm.img in l1_disk

## Testing and Review

### **Steps to Test**

### **Test Configuration (if applicable)**

## Reviewer Checklist

## Additional Notes / Concerns
